### PR TITLE
Add substrate account implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "rm -rf dist/ && yarn tsc",
     "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet",
     "lint:fix": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
-    "test": "jest --testTimeout=15000",
+    "test": "yarn test:jest && yarn test:auto",
+    "test:jest": "jest --testTimeout=15000",
+    "test:auto": "ts-node testsAuto/entryPoint.ts ",
     "pub": "yarn test && yarn lint:fix && yarn build && cp package.json dist/ && cd dist",
     "doc": "typedoc"
   },
@@ -15,6 +17,7 @@
   "author": "PtitLuca <luca.georges-francois@epitech.eu>",
   "license": "MIT",
   "devDependencies": {
+    "@solana/web3.js": "^1.29.0",
     "@types/elliptic": "^6.4.13",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.9.1",
@@ -22,9 +25,11 @@
     "@typescript-eslint/eslint-plugin": "^4.31.0",
     "@typescript-eslint/parser": "^4.31.0",
     "arraybuffer-to-string": "^1.0.2",
+    "bip39": "^3.0.4",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "ethers": "^5.4.6",
     "jest": "^27.1.1",
     "prettier": "^2.4.0",
     "ts-jest": "^27.0.5",
@@ -34,13 +39,13 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
-    "bip39": "^3.0.4",
-    "ethers": "^5.4.6",
-    "@solana/web3.js": "^1.29.0",
+    "@polkadot/keyring": "^7.4.1",
+    "@polkadot/util-crypto": "^7.4.1",
     "@types/sha.js": "^2.4.0",
     "avalanche": "^3.9.0",
     "axios": "^0.21.4",
     "form-data": "^4.0.0",
-    "sha.js": "^2.4.11"
+    "sha.js": "^2.4.11",
+    "ts-node": "^10.3.0"
   }
 }

--- a/src/accounts/account.ts
+++ b/src/accounts/account.ts
@@ -7,6 +7,7 @@ import { BaseMessage } from "../messages/message";
 export enum ChainType {
     Ethereum = "ETH",
     Solana = "SOL",
+    Substrate = "DOT",
 }
 
 /**

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -1,5 +1,6 @@
 import * as base from "./account";
 import * as ethereum from "./ethereum";
 import * as solana from "./solana";
+import * as substrate from "./substrate";
 
-export { base, ethereum, solana };
+export { base, ethereum, solana, substrate };

--- a/src/accounts/substrate.ts
+++ b/src/accounts/substrate.ts
@@ -1,0 +1,83 @@
+import { Account, ChainType } from "./account";
+import { BaseMessage, GetVerificationBuffer } from "../messages/message";
+
+import { Keyring } from "@polkadot/keyring";
+import { KeyringPair } from "@polkadot/keyring/types";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { generateMnemonic } from "@polkadot/util-crypto/mnemonic/bip39";
+
+/**
+ * DOTAccount implements the Account class for the substrate protocol.
+ *  It is used to represent a substrate account when publishing a message on the Aleph network.
+ */
+class DOTAccount extends Account {
+    private pair: KeyringPair;
+    constructor(pair: KeyringPair) {
+        const publicKey: string = Buffer.from(pair.publicKey).toString("hex");
+        super(pair.address, publicKey);
+        this.pair = pair;
+    }
+
+    GetChain(): ChainType {
+        return ChainType.Substrate;
+    }
+
+    /**
+     * The Sign method provides a way to sign a given Aleph message using a substrate account.
+     * The full message is not used as the payload, only fields of the BaseMessage type are.
+     *
+     * The sign method of the package 'polkadot' is used as the signature method.
+     *
+     * @param message The Aleph message to sign, using some of its fields.
+     */
+    Sign(message: BaseMessage): Promise<string> {
+        const buffer = GetVerificationBuffer(message);
+        return new Promise((resolve) => {
+            const signed = `0x${Buffer.from(this.pair.sign(buffer)).toString("hex")}`;
+
+            resolve(
+                JSON.stringify({
+                    curve: "sr25519",
+                    data: signed,
+                }),
+            );
+        });
+    }
+}
+
+/**
+ * Creates a new substrate account using a randomly generated substrate keyring.
+ */
+export async function NewAccount(): Promise<DOTAccount> {
+    const mnemonic = generateMnemonic();
+
+    return await ImportAccountFromMnemonic(mnemonic);
+}
+
+/**
+ * Imports a substrate account given a mnemonic and the 'polkadot' package.
+ *
+ * It creates an substrate wallet containing information about the account, extracted in the DOTAccount constructor.
+ *
+ * @param mnemonic The mnemonic of the account to import.
+ */
+export async function ImportAccountFromMnemonic(mnemonic: string): Promise<DOTAccount> {
+    const keyRing = new Keyring({ type: "sr25519" });
+
+    await cryptoWaitReady();
+    return new DOTAccount(keyRing.createFromUri(mnemonic, { name: "sr25519" }));
+}
+
+/**
+ * Imports a substrate account given a private key and the 'polkadot/keyring' package's class.
+ *
+ * It creates a substrate wallet containing information about the account, extracted in the DOTAccount constructor.
+ *
+ * @param privateKey The private key of the account to import.
+ */
+export async function ImportAccountFromPrivateKey(privateKey: string): Promise<DOTAccount> {
+    const keyRing = new Keyring({ type: "sr25519" });
+
+    await cryptoWaitReady();
+    return new DOTAccount(keyRing.createFromUri(privateKey, { name: "sr25519" }));
+}

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_API_V2 = "https://api2.aleph.im";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,4 @@ import * as aggregate from "./messages/aggregate/index";
 import * as post from "./messages/post/index";
 import * as store from "./messages/store/index";
 
-const DEFAULT_API_V2 = "https://api2.aleph.im";
-
-export { DEFAULT_API_V2, accounts, aggregate, post, store };
+export { accounts, aggregate, post, store };

--- a/src/messages/aggregate/get.ts
+++ b/src/messages/aggregate/get.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { DEFAULT_API_V2 } from "../../index";
+import { DEFAULT_API_V2 } from "../../global";
 
 type AggregateGetResponse<T> = {
     data: T;

--- a/src/messages/store/publish.ts
+++ b/src/messages/store/publish.ts
@@ -25,7 +25,7 @@ type StoreContent = BaseContent & {
  *
  * @param spc The configuration used to publish a store message.
  */
-export async function Publish(spc: StorePublishConfiguration): Promise<BaseMessage> {
+export async function Publish(spc: StorePublishConfiguration): Promise<string> {
     const hash = await PushFileToStorageEngine({
         APIServer: spc.APIServer,
         storageEngine: spc.storageEngine,
@@ -68,5 +68,5 @@ export async function Publish(spc: StorePublishConfiguration): Promise<BaseMessa
         APIServer: spc.APIServer,
     });
 
-    return message;
+    return hash;
 }

--- a/src/messages/store/publish.ts
+++ b/src/messages/store/publish.ts
@@ -1,4 +1,4 @@
-import { base } from "../../accounts/index";
+import * as base from "../../accounts/account";
 import { BaseContent, BaseMessage, MessageType, StorageEngine } from "../message";
 import { PushFileToStorageEngine, PutContentToStorageEngine } from "../create/publish";
 import { SignAndBroadcast } from "../create/signature";
@@ -25,7 +25,7 @@ type StoreContent = BaseContent & {
  *
  * @param spc The configuration used to publish a store message.
  */
-export async function Publish(spc: StorePublishConfiguration): Promise<string> {
+export async function Publish(spc: StorePublishConfiguration): Promise<BaseMessage> {
     const hash = await PushFileToStorageEngine({
         APIServer: spc.APIServer,
         storageEngine: spc.storageEngine,
@@ -68,5 +68,5 @@ export async function Publish(spc: StorePublishConfiguration): Promise<string> {
         APIServer: spc.APIServer,
     });
 
-    return hash;
+    return message;
 }

--- a/tests/accounts/ethereum.test.ts
+++ b/tests/accounts/ethereum.test.ts
@@ -1,11 +1,10 @@
 import * as bip39 from "bip39";
-
-import { accounts } from "../../src/index";
+import { ethereum } from "../index";
 import { ethers } from "ethers";
 
 describe("Ethereum accounts", () => {
     it("should create a new ethereum accounts", () => {
-        const account = accounts.ethereum.NewAccount();
+        const account = ethereum.NewAccount();
 
         expect(account.address).not.toBe("");
         expect(account.publicKey).not.toBe("");
@@ -13,7 +12,7 @@ describe("Ethereum accounts", () => {
 
     it("should import an ethereum accounts using a mnemonic", () => {
         const mnemonic = bip39.generateMnemonic();
-        const account = accounts.ethereum.ImportAccountFromMnemonic(mnemonic);
+        const account = ethereum.ImportAccountFromMnemonic(mnemonic);
 
         expect(account.address).not.toBe("");
         expect(account.publicKey).not.toBe("");
@@ -22,7 +21,7 @@ describe("Ethereum accounts", () => {
     it("should import an ethereum accounts using a private key", () => {
         const mnemonic = bip39.generateMnemonic();
         const wallet = ethers.Wallet.fromMnemonic(mnemonic);
-        const account = accounts.ethereum.ImportAccountFromPrivateKey(wallet.privateKey);
+        const account = ethereum.ImportAccountFromPrivateKey(wallet.privateKey);
 
         expect(account.address).not.toBe("");
         expect(account.publicKey).toBe(wallet.publicKey);

--- a/tests/accounts/solana.test.ts
+++ b/tests/accounts/solana.test.ts
@@ -1,10 +1,11 @@
 import * as solanajs from "@solana/web3.js";
-import { accounts, DEFAULT_API_V2, post } from "../../src/index";
 import { StorageEngine } from "../../src/messages/message";
+import { post, solana } from "../index";
+import { DEFAULT_API_V2 } from "../../src/global";
 
 describe("Solana accounts", () => {
     it("should create a new solana accounts", () => {
-        const account = accounts.solana.NewAccount();
+        const account = solana.NewAccount();
 
         expect(account.address).not.toBe("");
         expect(account.publicKey).not.toBe("");
@@ -12,14 +13,14 @@ describe("Solana accounts", () => {
 
     it("should import an solana accounts using a private key", () => {
         const keyPair = new solanajs.Keypair();
-        const account = accounts.solana.ImportAccountFromPrivateKey(keyPair.secretKey);
+        const account = solana.ImportAccountFromPrivateKey(keyPair.secretKey);
 
         expect(account.address).not.toBe("");
         expect(account.publicKey).toBe(keyPair.publicKey.toString());
     });
 
     it("should publish a post message correctly", async () => {
-        const account = accounts.solana.NewAccount();
+        const account = solana.NewAccount();
         const content: { body: string } = {
             body: "Hello World",
         };

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,0 +1,8 @@
+import * as ethereum from "../src/accounts/ethereum";
+import * as solana from "../src/accounts/solana";
+
+import * as aggregate from "../src/messages/aggregate/index";
+import * as post from "../src/messages/post/index";
+import * as store from "../src/messages/store/index";
+
+export { ethereum, solana, aggregate, post, store };

--- a/tests/messages/aggregate/get.test.ts
+++ b/tests/messages/aggregate/get.test.ts
@@ -1,5 +1,5 @@
-import { DEFAULT_API_V2 } from "../../../src";
-import { aggregate } from "../../../src/index";
+import { aggregate } from "../../index";
+import { DEFAULT_API_V2 } from "../../../src/global";
 
 describe("Aggregate message retrieve test", () => {
     it("should retrieve an existing aggregate message", async () => {

--- a/tests/messages/aggregate/publish.test.ts
+++ b/tests/messages/aggregate/publish.test.ts
@@ -1,6 +1,6 @@
-import { ethereum } from "../../../src/accounts/index";
-import { aggregate, DEFAULT_API_V2 } from "../../../src";
 import { StorageEngine } from "../../../src/messages/message";
+import { aggregate, ethereum } from "../../index";
+import { DEFAULT_API_V2 } from "../../../src/global";
 
 const mnemonic = "exit canvas recycle vault excite battle short roof unlock limb attract device";
 

--- a/tests/messages/post/publish.test.ts
+++ b/tests/messages/post/publish.test.ts
@@ -1,11 +1,11 @@
-import { accounts, post } from "../../../src";
 import { StorageEngine } from "../../../src/messages/message";
-import { DEFAULT_API_V2 } from "../../../src";
+import { ethereum, post } from "../../index";
+import { DEFAULT_API_V2 } from "../../../src/global";
 import { v4 as uuidv4 } from "uuid";
 
 describe("Post publish tests", () => {
     it("should publish post message correctly", async () => {
-        const account = accounts.ethereum.NewAccount();
+        const account = ethereum.NewAccount();
         const content: { body: string } = {
             body: "Hello World",
         };
@@ -24,7 +24,7 @@ describe("Post publish tests", () => {
     });
 
     it("should amend post message correctly", async () => {
-        const account = accounts.ethereum.NewAccount();
+        const account = ethereum.NewAccount();
         const postType = uuidv4();
         const content: { body: string } = {
             body: "Hello World",

--- a/tests/messages/store/get.test.ts
+++ b/tests/messages/store/get.test.ts
@@ -1,6 +1,7 @@
-import { DEFAULT_API_V2, store } from "../../../src";
+import { store } from "../../index";
+import { DEFAULT_API_V2 } from "../../../src/global";
 
-export function ArraybufferToString(ab: ArrayBuffer) {
+export function ArraybufferToString(ab: ArrayBuffer): string {
     return new TextDecoder().decode(ab);
 }
 

--- a/testsAuto/accounts/index.ts
+++ b/testsAuto/accounts/index.ts
@@ -1,0 +1,6 @@
+import * as substrateTests from "./substrate.auto";
+
+/**
+ * Export all your customs tests for accounts here
+ */
+export { substrateTests };

--- a/testsAuto/accounts/substrate.auto.ts
+++ b/testsAuto/accounts/substrate.auto.ts
@@ -1,0 +1,124 @@
+import * as bip39 from "bip39";
+import assert = require("assert");
+import { mnemonicToMiniSecret } from "@polkadot/util-crypto";
+
+import { testsFunc } from "../index";
+import { accounts, aggregate } from "../../src";
+import { DEFAULT_API_V2 } from "../../src/global";
+import { StorageEngine } from "../../src/messages/message";
+
+/**
+ * This is the first test of the test bach for substrate.
+ * It should create a new substrate account and check if it worked.
+ *
+ * For the assertion comparison, the `assert` standard library is used.
+ * If the assertion failed, you must catch the error message and display it while returning false.
+ */
+async function createAccountTest(): Promise<boolean> {
+    const account = await accounts.substrate.NewAccount();
+
+    try {
+        assert.notStrictEqual(account.address, "");
+        assert.notStrictEqual(account.publicKey, "");
+    } catch (e: unknown) {
+        console.error(`createAccountTest: ${e}`);
+        return false;
+    }
+    return true;
+}
+
+async function importAccountFromMnemonicTest(): Promise<boolean> {
+    const mnemonic = bip39.generateMnemonic();
+    const account = await accounts.substrate.ImportAccountFromMnemonic(mnemonic);
+
+    try {
+        assert.notStrictEqual(account.address, "");
+        assert.notStrictEqual(account.publicKey, "");
+    } catch (e: unknown) {
+        console.error(`importAccountFromMnemonicTest: ${e}`);
+        return false;
+    }
+    return true;
+}
+
+async function importAccountFromPrivateKeyTest(): Promise<boolean> {
+    const mnemonic = bip39.generateMnemonic();
+    const account = await accounts.substrate.ImportAccountFromMnemonic(mnemonic);
+    const secretKey = `0x${Buffer.from(mnemonicToMiniSecret(mnemonic)).toString("hex")}`;
+    const importedAccount = await accounts.substrate.ImportAccountFromPrivateKey(secretKey);
+
+    try {
+        assert.strictEqual(account.address, importedAccount.address);
+        assert.notStrictEqual(importedAccount.publicKey, "");
+    } catch (e: unknown) {
+        console.error(`importAccountFromPrivateKeyTest: ${e}`);
+        return false;
+    }
+    return true;
+}
+
+async function PublishAggregate(): Promise<boolean> {
+    const account = await accounts.substrate.NewAccount();
+    const key = "cheer";
+    const content: { body: string } = {
+        body: "Typescript sdk",
+    };
+
+    await aggregate.Publish({
+        account: account,
+        key: key,
+        content: content,
+        channel: "TEST",
+        storageEngine: StorageEngine.IPFS,
+        inlineRequested: true,
+        APIServer: DEFAULT_API_V2,
+    });
+
+    type exceptedType = {
+        cheer: {
+            body: string;
+        };
+    };
+    const amends = await aggregate.Get<exceptedType>({
+        APIServer: DEFAULT_API_V2,
+        address: account.address,
+        keys: [key],
+    });
+
+    try {
+        assert.strictEqual(amends.cheer.body, content.body);
+    } catch (e: unknown) {
+        console.error(`PublishPostMessage: ${e}`);
+        return false;
+    }
+    return true;
+}
+
+/**
+ * SubstrateTests controls the flow of your custom tests for substrate protocol.
+ * Every test is represented by a function related to the `testsFunc` Type.
+ * The array `testBatch` Contains all the customs tests functions in a predefined order.
+ *
+ * Every test will be executed in order, then a boolean according to the failure or success of your batch
+ * will be returned.
+ *
+ * In order to produce a new test bach you have to copy this function in a new file with
+ * an appropriate name, import `assert` library and `testsFunc` type.
+ */
+export default async function substrateTests(): Promise<boolean> {
+    let passed = true;
+    let res: boolean;
+    const testBatch: testsFunc[] = [
+        createAccountTest,
+        importAccountFromMnemonicTest,
+        importAccountFromPrivateKeyTest,
+        PublishAggregate,
+    ];
+
+    for (let i = 0; i < testBatch.length; i++) {
+        res = await testBatch[i]();
+        console.log(`Test [${i + 1}-${res ? "Success" : "Failure"}]\t${testBatch[i].name}`);
+        passed = res ? passed : false;
+    }
+    return passed;
+}

--- a/testsAuto/entryPoint.ts
+++ b/testsAuto/entryPoint.ts
@@ -1,0 +1,27 @@
+import { accountTests, testsFunc } from "./index";
+
+/**
+ *  launchTestsAuto represents the entry point of testsAuto.
+ *  It launches all of your customs test batches that you provide in the `testBatch` array.
+ *
+ *  For each custom test batches a message will be written in the console according to the name of the test batch
+ *  followed by the result of each test contained in the suits.
+ *
+ *  All tests will be computed with their result displayed in the console.
+ *  Then, the program will exit with either an error or success status.
+ *
+ *  Look at `testsAuto/accounts/substrate.auto.ts` to learn more about making custom test.
+ */
+async function launchTestsAuto(): Promise<void> {
+    let passed = true;
+    const testBatch: testsFunc[] = [accountTests.substrateTests.default];
+
+    for (let i = 0; i < testBatch.length; i++) {
+        console.log(`---Starting: ${testBatch[i].name}`);
+        passed = (await testBatch[i]()) ? passed : false;
+    }
+    if (!passed) process.exit(1);
+    else process.exit(0);
+}
+
+launchTestsAuto();

--- a/testsAuto/index.ts
+++ b/testsAuto/index.ts
@@ -1,0 +1,8 @@
+import * as accountTests from "./accounts/index";
+
+type testsFunc = () => Promise<boolean>;
+
+/**
+ * Export all your customs tests here
+ */
+export { testsFunc, accountTests };

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,6 +279,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.15.3", "@babel/runtime@^7.15.4":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.0.tgz#e27b977f2e2088ba24748bf99b5e1dece64e4f0b"
+  integrity sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.15.4", "@babel/template@^7.3.3":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
@@ -315,6 +322,18 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -890,6 +909,112 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@polkadot/keyring@^7.4.1":
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-7.7.1.tgz#0ab6a8d104669ead3e269cf2c185346b24dfbd36"
+  integrity sha512-MzdwUeR5BjqEqSnW1SVg1mMaUPkirGcLd60vsp187qf/y9IaI+ZinkeP50d/GxldRobNL/bOdiOuV3bSulUvSQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@polkadot/util" "7.7.1"
+    "@polkadot/util-crypto" "7.7.1"
+
+"@polkadot/networks@7.7.1":
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-7.7.1.tgz#de9674a355bd4f68d650e3dd580d717d83ea4161"
+  integrity sha512-ghUA9jd+12lfbKclPIxRQBmvfd1+BoECr5C8t+2rfM5plE+1f1Ucdrpz9wQ362+WNlnP4q1u9yB1zQlFM+K6yQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+
+"@polkadot/util-crypto@7.7.1", "@polkadot/util-crypto@^7.4.1":
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-7.7.1.tgz#6c3b84558d4e971cc0a7190f99e34ce801eb498d"
+  integrity sha512-K269URC/ofbYM1vFSIVLbuRi4Z+9bMdyJQ1k+59+jx0VwYu50l9vzNhFO8WMGoBZ6eDzqQkeWj7usCTKlU9xUw==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@polkadot/networks" "7.7.1"
+    "@polkadot/util" "7.7.1"
+    "@polkadot/wasm-crypto" "^4.2.1"
+    "@polkadot/x-randomvalues" "7.7.1"
+    base-x "^3.0.9"
+    base64-js "^1.5.1"
+    blakejs "^1.1.1"
+    bn.js "^4.12.0"
+    create-hash "^1.2.0"
+    ed2curve "^0.3.0"
+    elliptic "^6.5.4"
+    hash.js "^1.1.7"
+    js-sha3 "^0.8.0"
+    scryptsy "^2.1.0"
+    tweetnacl "^1.0.3"
+    xxhashjs "^0.2.2"
+
+"@polkadot/util@7.7.1":
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-7.7.1.tgz#b9c74f8c242669ff8ce26a3101630231914de7c7"
+  integrity sha512-REw11iHZKUm7GeC7Ktx1HguT9y76mbmiVtZJyNXpUTDKmfm6z+SMqs3pOCL/rvzqm+6M3ag6ffRrlzTTgh0HAg==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@polkadot/x-textdecoder" "7.7.1"
+    "@polkadot/x-textencoder" "7.7.1"
+    "@types/bn.js" "^4.11.6"
+    bn.js "^4.12.0"
+    camelcase "^6.2.0"
+    ip-regex "^4.3.0"
+
+"@polkadot/wasm-crypto-asmjs@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-4.2.1.tgz#6b7eae1c011709f8042dfd30872a5fc5e9e021c0"
+  integrity sha512-ON9EBpTNDCI3QRUmuQJIegYoAcwvxDaNNA7uwKTaEEStu8LjCIbQxbt4WbOBYWI0PoUpl4iIluXdT3XZ3V3jXA==
+  dependencies:
+    "@babel/runtime" "^7.15.3"
+
+"@polkadot/wasm-crypto-wasm@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-4.2.1.tgz#2a86f9b405e7195c3f523798c6ce4afffd19737e"
+  integrity sha512-Rs2CKiR4D+2hKzmKBfPNYxcd2E8NfLWia0av4fgicjT9YsWIWOGQUi9AtSOfazPOR9FrjxKJy+chQxAkcfKMnQ==
+  dependencies:
+    "@babel/runtime" "^7.15.3"
+
+"@polkadot/wasm-crypto@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-4.2.1.tgz#4d09402f5ac71a90962fb58cbe4b1707772a4fb6"
+  integrity sha512-C/A/QnemOilRTLnM0LfhPY2N/x3ZFd1ihm9sXYyuh98CxtekSVYI9h4IJ5Jrgz5imSUHgvt9oJLqJ5GbWQV/Zg==
+  dependencies:
+    "@babel/runtime" "^7.15.3"
+    "@polkadot/wasm-crypto-asmjs" "^4.2.1"
+    "@polkadot/wasm-crypto-wasm" "^4.2.1"
+
+"@polkadot/x-global@7.7.1":
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-7.7.1.tgz#ab390aa07807d62a7ec0fa2fd6e7c4837524c227"
+  integrity sha512-S7MYqEtcfMgWA64qR09Z8O3zbaRyyW1y2qtvn04dexPesuEPOw2W5+WBHss8UAI/aVxjlG+d2D3OlYUr+IOO9Q==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+
+"@polkadot/x-randomvalues@7.7.1":
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-7.7.1.tgz#37edb6920bac4f6c6c7620f02ef9dd5b43405a5b"
+  integrity sha512-dFhxei2TP3cWepfITDSq6eaBbdsP8TPBQagincqJynt5EaU0pzQ5psMBMJ/rAYy194oEpg0ED16XK/iFdZ42rA==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@polkadot/x-global" "7.7.1"
+
+"@polkadot/x-textdecoder@7.7.1":
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-7.7.1.tgz#bfcf8f8a7ce620ca72a649dd0a322a4476a51a28"
+  integrity sha512-2+kYLVxjdtbuxcIDMdEiBK+GvCs/M8QdKVmTGLTb47PphSeiMKLu8qjy1ygBJeaFeQOZxIj1f8IJ5ICI9TlVcA==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@polkadot/x-global" "7.7.1"
+
+"@polkadot/x-textencoder@7.7.1":
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-7.7.1.tgz#7dc5b0165e3b6ad6882904169ad3362487ada92b"
+  integrity sha512-pRTG7F6EYilkbkyxfWOV1LXCVohcVnFPVfPvGydHsDJ3kGZ4n+L9PuJ+t3WKwd6tirEDUIBGe2eNEl/arcWzTw==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@polkadot/x-global" "7.7.1"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -936,6 +1061,26 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.16"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.16.tgz#bc12c74b7d65e82d29876b5d0baf5c625ac58702"
@@ -976,7 +1121,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/bn.js@^4.11.5":
+"@types/bn.js@^4.11.5", "@types/bn.js@^4.11.6":
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
   integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
@@ -1217,12 +1362,17 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.2.4:
+acorn@^8.2.4, acorn@^8.4.1:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
   integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
@@ -1302,6 +1452,11 @@ anymatch@^3.0.3:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1456,7 +1611,14 @@ base-x@^3.0.2:
   dependencies:
     safe-buffer "^5.0.1"
 
-base64-js@^1.3.1:
+base-x@^3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
+  integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
+base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -1481,12 +1643,17 @@ bip39@3.0.4, bip39@^3.0.4:
     pbkdf2 "^3.0.9"
     randombytes "^2.0.1"
 
+blakejs@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.1.tgz#bf313053978b2cd4c444a48795710be05c785702"
+  integrity sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==
+
 bn.js@5.2.0, bn.js@^5.0.0, bn.js@^5.1.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
+bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9, bn.js@^4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
@@ -1825,6 +1992,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-fetch@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
@@ -1879,6 +2051,11 @@ cssstyle@^2.3.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
+
+cuint@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
+  integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
 
 data-urls@^2.0.0:
   version "2.0.0"
@@ -1951,6 +2128,11 @@ diff-sequences@^27.0.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"
   integrity sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==
 
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -1981,12 +2163,19 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
+ed2curve@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ed2curve/-/ed2curve-0.3.0.tgz#322b575152a45305429d546b071823a93129a05d"
+  integrity sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==
+  dependencies:
+    tweetnacl "1.x.x"
+
 electron-to-chromium@^1.3.867:
   version "1.3.871"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.871.tgz#6e87365fd72037a6c898fb46050ad4be3ac9ef62"
   integrity sha512-qcLvDUPf8DSIMWarHT2ptgcqrYg62n3vPA7vhrOF24d8UNzbUBaHu2CySiENR3nEDzYgaN60071t0F6KLYMQ7Q==
 
-elliptic@6.5.4, elliptic@^6.5.2, elliptic@^6.5.3:
+elliptic@6.5.4, elliptic@^6.5.2, elliptic@^6.5.3, elliptic@^6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -2587,7 +2776,7 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
-hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3:
+hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -2711,6 +2900,11 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+ip-regex@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
+  integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
 is-arguments@^1.0.4:
   version "1.1.1"
@@ -3540,7 +3734,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -4082,6 +4276,11 @@ scrypt-js@3.0.1:
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
   integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
 
+scryptsy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/scryptsy/-/scryptsy-2.1.0.tgz#8d1e8d0c025b58fdd25b6fa9a0dc905ee8faa790"
+  integrity sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==
+
 secp256k1@^4.0.0, secp256k1@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.2.tgz#15dd57d0f0b9fdb54ac1fa1694f40e5e9a54f4a1"
@@ -4410,6 +4609,24 @@ ts-jest@^27.0.5:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-node@^10.3.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.4.0.tgz#680f88945885f4e6cf450e7f0d6223dd404895f7"
+  integrity sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    yn "3.1.1"
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -4422,7 +4639,7 @@ tsutils@^3.21.0:
   dependencies:
     tslib "^1.8.1"
 
-tweetnacl@^1.0.0, tweetnacl@^1.0.3:
+tweetnacl@1.x.x, tweetnacl@^1.0.0, tweetnacl@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
   integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
@@ -4708,6 +4925,13 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
+xxhashjs@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/xxhashjs/-/xxhashjs-0.2.2.tgz#8a6251567621a1c46a5ae204da0249c7f8caa9d8"
+  integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
+  dependencies:
+    cuint "^0.2.2"
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
@@ -4740,3 +4964,8 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
###  What's new:

- Substrate account:   Generate new account - import from mnemonic, private key - sign messages.
- Jest Tests:                 Changes made on imports for all Jest's tests to allow running TestsAuto and Jest.
- TestsAuto:                 A handmade solution that allows testing substrate cause it is not suitable with the Jest framework.

### Substrate Details:

- Add 2 news dependencies: `@polkadot/keyring`, `@polkadot/util-crypto` in package.json
- All methods and class's related to this change are located in `./src/accounts/substrate.ts`

### Jest Tests:

- Creation of a new `index.ts` in the test dir to make jest's tests refer to these imports.
- The main diff with `index.ts` located in src is that it does not import substrate account cause it's not supported and make jest crash
- Creation of a new file called `global.ts` in src to move the `DEFAULT_API_V2` variable.
- Update every jest test to make them refer to `index.ts` located in tests dir.
- Add 2 news scripts in package.json: test:auto and test:jest to launch all tests simultaneously

### TestsAuto:

- Add 1 new dependency to run tests with `ts-node` 
- All stuff related to TestsAuto are located in `./testsAuto` dir at the root
- Tests for substrate are located in `./testAuto/accounts/substrate.auto.ts`. They are exported with `substrateTests()` and launched in `./testAuto/entrypoint.ts`
- You can easily add new tests suits by adding yours in `testBatch` array.
- TestsAuto will run all your tests and logged errors or successes in the console before exiting with the appropriate status: 0 or 1
