### PR TITLE
Fix hex avalanche message not being posted

### DIFF
--- a/src/accounts/avalanche.ts
+++ b/src/accounts/avalanche.ts
@@ -14,7 +14,7 @@ export class AvalancheAccount extends Account {
     private signer;
 
     constructor(signer: KeyPair) {
-        super(signer.getAddress().toString("hex"), signer.getPublicKey().toString("hex"));
+        super(signer.getAddressString(), signer.getPublicKeyString());
         this.signer = signer;
     }
 
@@ -28,7 +28,8 @@ export class AvalancheAccount extends Account {
      * @param content The content to encrypt.
      */
     encrypt(content: Buffer): Buffer {
-        return secp256k1_encrypt(this.publicKey, content);
+        const publicKey = this.signer.getPublicKey().toString("hex");
+        return secp256k1_encrypt(publicKey, content);
     }
 
     /**
@@ -65,7 +66,10 @@ export class AvalancheAccount extends Account {
         const digestHex = digest.toString("hex");
         const digestBuff = AvaBuff.from(digestHex, "hex");
 
-        return this.signer.sign(digestBuff).toString();
+        const signatureBuffer = this.signer.sign(digestBuff);
+        const bintools = BinTools.getInstance();
+
+        return bintools.cb58Encode(signatureBuffer);
     }
 }
 

--- a/tests/accounts/avalanche.test.ts
+++ b/tests/accounts/avalanche.test.ts
@@ -1,4 +1,6 @@
-import { avalanche } from "../index";
+import { avalanche, post } from "../index";
+import { DEFAULT_API_V2 } from "../../src/global";
+import { ItemType } from "../../src/messages/message";
 
 describe("Avalanche accounts", () => {
     it("should create a new Avalanche account", async () => {
@@ -46,5 +48,34 @@ describe("Avalanche accounts", () => {
         const d = account.decrypt(c);
 
         expect(d).toStrictEqual(msg);
+    });
+
+    it("should publish a post message correctly", async () => {
+        const { account } = await avalanche.NewAccount();
+        const content: { body: string } = {
+            body: "This message was posted from the typescript-SDK test suite",
+        };
+
+        const msg = await post.Publish({
+            APIServer: DEFAULT_API_V2,
+            channel: "TEST",
+            inlineRequested: true,
+            storageEngine: ItemType.ipfs,
+            account: account,
+            postType: "custom_type",
+            content: content,
+        });
+
+        const amends = await post.Get({
+            types: "custom_type",
+            APIServer: DEFAULT_API_V2,
+            pagination: 200,
+            page: 1,
+            refs: [],
+            addresses: [],
+            tags: [],
+            hashes: [msg.item_hash],
+        });
+        expect(amends.posts[0].content).toStrictEqual(content);
     });
 });


### PR DESCRIPTION
Switched to default base58 encoding for avalanche issued message.

A [test case](https://github.com/aleph-im/aleph-sdk-ts/blob/quickfix-ava-cb58/tests/accounts/avalanche.test.ts#L53) was written to ensure compatibility.