### PR TITLE
Remove public key from the Account class

### DIFF
--- a/src/accounts/account.ts
+++ b/src/accounts/account.ts
@@ -8,11 +8,9 @@ import { BaseMessage, Chain } from "../messages/message";
  */
 export abstract class Account {
     readonly address: string;
-    readonly publicKey: string;
 
-    protected constructor(address: string, publicKey: string) {
+    protected constructor(address: string) {
         this.address = address;
-        this.publicKey = publicKey;
     }
 
     abstract GetChain(): Chain;

--- a/src/accounts/avalanche.ts
+++ b/src/accounts/avalanche.ts
@@ -14,7 +14,7 @@ export class AvalancheAccount extends Account {
     private signer;
 
     constructor(signer: KeyPair) {
-        super(signer.getAddressString(), signer.getPublicKeyString());
+        super(signer.getAddressString());
         this.signer = signer;
     }
 

--- a/src/accounts/ethereum.ts
+++ b/src/accounts/ethereum.ts
@@ -12,7 +12,7 @@ import { decrypt as secp256k1_decrypt, encrypt as secp256k1_encrypt } from "ecie
 export class ETHAccount extends Account {
     private wallet: ethers.Wallet;
     constructor(wallet: ethers.Wallet) {
-        super(wallet.address, wallet.publicKey);
+        super(wallet.address);
         this.wallet = wallet;
     }
 
@@ -26,7 +26,7 @@ export class ETHAccount extends Account {
      * @param content The content to encrypt.
      */
     encrypt(content: Buffer): Buffer {
-        return secp256k1_encrypt(this.publicKey, content);
+        return secp256k1_encrypt(this.wallet.publicKey, content);
     }
 
     /**

--- a/src/accounts/nuls.ts
+++ b/src/accounts/nuls.ts
@@ -9,7 +9,6 @@ import { BaseMessage, Chain } from "../messages/message";
 import { GetVerificationBuffer } from "../messages";
 import { decrypt as secp256k1_decrypt, encrypt as secp256k1_encrypt } from "eciesjs";
 
-export const hexRegEx = /([0-9]|[a-f])/gim;
 export type ChainNAddress = {
     chain_id?: number;
     address_type?: number;
@@ -25,9 +24,12 @@ export type NULSImportConfig = {
  */
 export class NULSAccount extends Account {
     private readonly privateKey: string;
+    private readonly publicKey: string;
+
     constructor(address: string, publicKey: string, privateKey: string) {
-        super(address, publicKey);
+        super(address);
         this.privateKey = privateKey;
+        this.publicKey = publicKey;
     }
 
     GetChain(): Chain {
@@ -145,12 +147,7 @@ export async function ImportAccountFromPrivateKey(
  * @param body The array to XOR.
  */
 export function getXOR(body: Uint8Array): number {
-    let xor = 0;
-
-    for (let i = 0; i < body.length; i += 1) {
-        xor ^= body[i];
-    }
-    return xor;
+    return body.reduce((xor, i) => (xor ^= i), 0);
 }
 
 /**
@@ -241,8 +238,8 @@ export function hashTwice(buffer: Buffer): Buffer {
  *
  * @param input The input to verify.
  */
-export function isHex<T>(input: T): boolean {
-    return typeof input === "string" && (input.match(hexRegEx) || []).length === input.length;
+export function isHex(input: string): boolean {
+    return /([0-9]|[a-f])/gim.test(input);
 }
 
 /**

--- a/src/accounts/nuls2.ts
+++ b/src/accounts/nuls2.ts
@@ -19,9 +19,12 @@ export type NULS2ImportConfig = {
  */
 export class NULS2Account extends Account {
     private readonly privateKey: string;
+    private readonly publicKey: string;
+
     constructor(address: string, publicKey: string, privateKey: string) {
-        super(address, publicKey);
+        super(address);
         this.privateKey = privateKey;
+        this.publicKey = publicKey;
     }
 
     GetChain(): Chain {

--- a/src/accounts/solana.ts
+++ b/src/accounts/solana.ts
@@ -13,7 +13,7 @@ export class SOLAccount extends Account {
     private wallet: solanajs.Keypair;
 
     constructor(wallet: solanajs.Keypair) {
-        super(wallet.publicKey.toString(), wallet.publicKey.toString());
+        super(wallet.publicKey.toString());
         this.wallet = wallet;
     }
 
@@ -91,7 +91,7 @@ export class SOLAccount extends Account {
             resolve(
                 JSON.stringify({
                     signature: base58.encode(bufferSignature),
-                    publicKey: this.publicKey,
+                    publicKey: this.wallet.publicKey.toString(),
                 }),
             );
         });

--- a/src/accounts/substrate.ts
+++ b/src/accounts/substrate.ts
@@ -14,8 +14,7 @@ import { generateMnemonic } from "@polkadot/util-crypto/mnemonic/bip39";
 export class DOTAccount extends Account {
     private pair: KeyringPair;
     constructor(pair: KeyringPair) {
-        const publicKey: string = Buffer.from(pair.publicKey).toString("hex");
-        super(pair.address, publicKey);
+        super(pair.address);
         this.pair = pair;
     }
 

--- a/tests/accounts/avalanche.test.ts
+++ b/tests/accounts/avalanche.test.ts
@@ -7,7 +7,6 @@ describe("Avalanche accounts", () => {
         const { account } = await avalanche.NewAccount();
 
         expect(account.address).not.toBe("");
-        expect(account.publicKey).not.toBe("");
     });
 
     it("should retreive an avalanche keypair from an hexadecimal private key", async () => {
@@ -15,7 +14,7 @@ describe("Avalanche accounts", () => {
 
         if (privateKey) {
             const accountFromPK = await avalanche.ImportAccountFromPrivateKey(privateKey);
-            expect(account.publicKey).toBe(accountFromPK.publicKey);
+            expect(account.address).toBe(accountFromPK.address);
         } else {
             fail();
         }
@@ -29,7 +28,7 @@ describe("Avalanche accounts", () => {
         const fromHex = await avalanche.ImportAccountFromPrivateKey(hexPrivateKey);
         const fromCb58 = await avalanche.ImportAccountFromPrivateKey(cb58PrivateKey);
 
-        expect(fromHex.publicKey).toBe(fromCb58.publicKey);
+        expect(fromHex.address).toBe(fromCb58.address);
     });
 
     it("Should encrypt some data with an Avalanche keypair", async () => {

--- a/tests/accounts/ethereum.test.ts
+++ b/tests/accounts/ethereum.test.ts
@@ -7,7 +7,6 @@ describe("Ethereum accounts", () => {
         const { account } = ethereum.NewAccount();
 
         expect(account.address).not.toBe("");
-        expect(account.publicKey).not.toBe("");
     });
 
     it("should import an ethereum accounts using a mnemonic", () => {
@@ -15,7 +14,6 @@ describe("Ethereum accounts", () => {
         const account = ethereum.ImportAccountFromMnemonic(mnemonic);
 
         expect(account.address).not.toBe("");
-        expect(account.publicKey).not.toBe("");
     });
 
     it("should import an ethereum accounts using a private key", () => {
@@ -24,7 +22,6 @@ describe("Ethereum accounts", () => {
         const account = ethereum.ImportAccountFromPrivateKey(wallet.privateKey);
 
         expect(account.address).not.toBe("");
-        expect(account.publicKey).toBe(wallet.publicKey);
     });
 
     it("Should encrypt some data with an Ethereum account", () => {

--- a/tests/accounts/nuls.test.ts
+++ b/tests/accounts/nuls.test.ts
@@ -7,7 +7,6 @@ describe("NULS accounts", () => {
         const { account } = await nuls.NewAccount();
 
         expect(account.address).not.toBe("");
-        expect(account.publicKey).not.toBe("");
         expect(account.GetChain()).toStrictEqual(Chain.NULS);
     });
 
@@ -16,7 +15,6 @@ describe("NULS accounts", () => {
         const account = await nuls.ImportAccountFromMnemonic(mnemonic);
 
         expect(account.address).not.toBe("");
-        expect(account.publicKey).not.toBe("");
         expect(account.GetChain()).toStrictEqual(Chain.NULS);
     });
 
@@ -26,7 +24,6 @@ describe("NULS accounts", () => {
         );
 
         expect(account.address).not.toBe("");
-        expect(account.publicKey).toBe("02a7e23f579821364bf186b2ee0fb2aa9e5faa57cd4f281599ca242d8d9faa8533");
         expect(account.address).toBe("6HgcLR5Yjc7yyMiteQZxTpuB6NYRiqWf");
     });
 

--- a/tests/accounts/nuls2.test.ts
+++ b/tests/accounts/nuls2.test.ts
@@ -8,7 +8,6 @@ describe("NULS2 accounts", () => {
         const { account } = await nuls2.NewAccount();
 
         expect(account.address).not.toBe("");
-        expect(account.publicKey).not.toBe("");
         expect(account.GetChain()).toStrictEqual(Chain.NULS2);
     });
 
@@ -17,7 +16,6 @@ describe("NULS2 accounts", () => {
         const account = await nuls2.ImportAccountFromMnemonic(mnemonic);
 
         expect(account.address).not.toBe("");
-        expect(account.publicKey).not.toBe("");
         expect(account.GetChain()).toStrictEqual(Chain.NULS2);
     });
 
@@ -27,7 +25,6 @@ describe("NULS2 accounts", () => {
         );
 
         expect(account.address).not.toBe("");
-        expect(account.publicKey).toBe("02a7e23f579821364bf186b2ee0fb2aa9e5faa57cd4f281599ca242d8d9faa8533");
         expect(account.address).toBe("NULSd6HgcLR5Yjc7yyMiteQZxTpuB6NYRiqWf");
     });
 
@@ -43,7 +40,6 @@ describe("NULS2 accounts", () => {
         const accountTwoPrefix = accountTwo.address.substring(0, 3);
         const accountTwoAddress = accountTwo.address.substring(4, accountTwo.address.length);
 
-        expect(accountOne.publicKey).toBe(accountTwo.publicKey);
         expect(accountOnePrefix).not.toBe(accountTwoPrefix);
         expect(accountOneAddress).toBe(accountTwoAddress);
     });

--- a/tests/accounts/solana.test.ts
+++ b/tests/accounts/solana.test.ts
@@ -2,15 +2,12 @@ import * as solanajs from "@solana/web3.js";
 import { ItemType } from "../../src/messages/message";
 import { post, solana } from "../index";
 import { DEFAULT_API_V2 } from "../../src/global";
-import nacl from "tweetnacl";
-import base58 from "bs58";
 
 describe("Solana accounts", () => {
     it("should create a new solana accounts", () => {
         const { account } = solana.NewAccount();
 
         expect(account.address).not.toBe("");
-        expect(account.publicKey).not.toBe("");
     });
 
     it("should import an solana accounts using a private key", () => {
@@ -18,7 +15,6 @@ describe("Solana accounts", () => {
         const account = solana.ImportAccountFromPrivateKey(keyPair.secretKey);
 
         expect(account.address).not.toBe("");
-        expect(account.publicKey).toBe(keyPair.publicKey.toString());
     });
 
     it("should publish a post message correctly", async () => {
@@ -50,41 +46,5 @@ describe("Solana accounts", () => {
             });
             expect(amends.posts[0].content).toStrictEqual(content);
         }, 1000);
-    });
-
-    it("Should encrypt content", async () => {
-        const { account } = solana.NewAccount();
-        const msg = Buffer.from("solana en avant les histoires");
-
-        const c = await account.encrypt(msg);
-        expect(c).not.toBe(msg);
-    });
-
-    it("Should encrypt and decrypt content", async () => {
-        const { account } = solana.NewAccount();
-        const msg = Buffer.from("solana en avant les histoires");
-
-        const c = await account.encrypt(msg);
-        const d = await account.decrypt(c);
-        expect(c).not.toBe(msg);
-        expect(d).toStrictEqual(msg);
-    });
-
-    it("Should not be decryptable with the public key", async () => {
-        const { account } = solana.NewAccount();
-        const msg = Buffer.from("solana en avant les histoires");
-
-        const c = await account.encrypt(msg);
-        const opts = {
-            nonce: c.slice(0, nacl.box.nonceLength),
-            ciphertext: c.slice(nacl.box.nonceLength),
-        };
-        const d = nacl.box.open(
-            opts.ciphertext,
-            opts.nonce,
-            base58.decode(account.publicKey),
-            base58.decode(account.publicKey),
-        );
-        expect(d).toBeNull();
     });
 });

--- a/testsAuto/accounts/substrate.auto.ts
+++ b/testsAuto/accounts/substrate.auto.ts
@@ -19,7 +19,6 @@ async function createAccountTest(): Promise<boolean> {
 
     try {
         assert.notStrictEqual(account.address, "");
-        assert.notStrictEqual(account.publicKey, "");
     } catch (e: unknown) {
         console.error(`createAccountTest: ${e}`);
         return false;
@@ -33,7 +32,6 @@ async function importAccountFromMnemonicTest(): Promise<boolean> {
 
     try {
         assert.notStrictEqual(account.address, "");
-        assert.notStrictEqual(account.publicKey, "");
     } catch (e: unknown) {
         console.error(`importAccountFromMnemonicTest: ${e}`);
         return false;
@@ -49,7 +47,6 @@ async function importAccountFromPrivateKeyTest(): Promise<boolean> {
 
     try {
         assert.strictEqual(account.address, importedAccount.address);
-        assert.notStrictEqual(importedAccount.publicKey, "");
     } catch (e: unknown) {
         console.error(`importAccountFromPrivateKeyTest: ${e}`);
         return false;


### PR DESCRIPTION
# Problem
The public key is only used on some chains. A side effect from this premature optimization is that it cannot be obtained from a web3 provider.

# Solution
Remove the public key from the parent Account class and derive it when needed on specific chains.