### PR TITLE
Fix forget message testing (due to API changes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet",
         "lint:fix": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
         "test": "yarn test:jest && yarn test:auto",
-        "test:jest": "jest --testTimeout=23000 --maxWorkers=2 --verbose",
+        "test:jest": "jest --testTimeout=60000 --maxWorkers=2 --verbose",
         "test:auto": "ts-node testsAuto/entryPoint.ts ",
         "pub": "yarn test && yarn lint:fix && yarn build && cp package.json dist/ && cd dist",
         "doc": "typedoc"

--- a/tests/messages/forget/publish.test.ts
+++ b/tests/messages/forget/publish.test.ts
@@ -15,8 +15,8 @@ describe("Forget publish tests", () => {
         const res = await post.Publish({
             APIServer: DEFAULT_API_V2,
             channel: "TEST",
-            inlineRequested: false,
-            storageEngine: ItemType.ipfs,
+            inlineRequested: true,
+            storageEngine: ItemType.inline,
             account: account,
             postType: postType,
             content: content,
@@ -27,7 +27,7 @@ describe("Forget publish tests", () => {
             channel: "TEST",
             hashes: [res.item_hash],
             inlineRequested: true,
-            storageEngine: ItemType.ipfs,
+            storageEngine: ItemType.inline,
             account: account,
         });
         expect(Fres.content).not.toBeNull();


### PR DESCRIPTION
Forget message structure has been updated in Aleph client