### PR TITLE
Miscealenous minor fixes on SOLAccount

### DIFF
--- a/src/accounts/solana.ts
+++ b/src/accounts/solana.ts
@@ -9,6 +9,7 @@ type WalletSignature = {
     signature: Uint8Array;
     publicKey: string;
 };
+
 interface MessageSigner {
     signMessage(message: Uint8Array): Promise<WalletSignature>;
     publicKey: PublicKey;
@@ -23,16 +24,13 @@ interface MessageSigner {
 export class SOLAccount extends Account {
     private wallet?: MessageSigner;
     private keypair?: Keypair;
-    public isKeypair: boolean;
 
     constructor(publicKey: PublicKey, walletOrKeypair: Keypair | MessageSigner) {
         super(publicKey.toString());
         if (walletOrKeypair instanceof Keypair) {
             this.keypair = walletOrKeypair;
-            this.isKeypair = true;
         } else {
             this.wallet = walletOrKeypair;
-            this.isKeypair = false;
         }
     }
 

--- a/src/accounts/solana.ts
+++ b/src/accounts/solana.ts
@@ -76,8 +76,8 @@ export class SOLAccount extends Account {
  *
  * @param privateKey The private key of the account to import.
  */
-export function ImportAccountFromPrivateKey(privateKey: Uint8Array): SOLAccount {
-    const keypair = Keypair.fromSecretKey(privateKey);
+export function ImportAccountFromPrivateKey(privateKey: string): SOLAccount {
+    const keypair = Keypair.fromSecretKey(Buffer.from(privateKey));
 
     return new SOLAccount(keypair.publicKey, keypair);
 }
@@ -88,7 +88,7 @@ export function ImportAccountFromPrivateKey(privateKey: Uint8Array): SOLAccount 
 export function NewAccount(): { account: SOLAccount; privateKey: Uint8Array } {
     const account = new Keypair();
 
-    return { account: ImportAccountFromPrivateKey(account.secretKey), privateKey: account.secretKey };
+    return { account: ImportAccountFromPrivateKey(account.secretKey.toString()), privateKey: account.secretKey };
 }
 
 /**

--- a/tests/accounts/solana.test.ts
+++ b/tests/accounts/solana.test.ts
@@ -12,7 +12,7 @@ describe("Solana accounts", () => {
 
     it("should import an solana accounts using a private key", () => {
         const keyPair = new solanajs.Keypair();
-        const account = solana.ImportAccountFromPrivateKey(keyPair.secretKey);
+        const account = solana.ImportAccountFromPrivateKey(keyPair.secretKey.toString());
 
         expect(account.address).not.toBe("");
     });
@@ -33,18 +33,17 @@ describe("Solana accounts", () => {
             content: content,
         });
 
-        setTimeout(async () => {
-            const amends = await post.Get({
-                types: "custom_type",
-                APIServer: DEFAULT_API_V2,
-                pagination: 200,
-                page: 1,
-                refs: [],
-                addresses: [],
-                tags: [],
-                hashes: [msg.item_hash],
-            });
-            expect(amends.posts[0].content).toStrictEqual(content);
-        }, 1000);
+        const amends = await post.Get({
+            types: "custom_type",
+            APIServer: DEFAULT_API_V2,
+            pagination: 200,
+            page: 1,
+            refs: [],
+            addresses: [],
+            tags: [],
+            hashes: [msg.item_hash],
+        });
+
+        expect(amends.posts[0].content).toStrictEqual(content);
     });
 });


### PR DESCRIPTION
- `ImportAccountFromPrivateKey` now takes a `string` argument (Uint8Array previously)
- Removal of a useless public variable `isKeypair` on the SOLAccount class (thanks @Rgascoin )