### PR TITLE
Add support for request proxying via CRN host

### DIFF
--- a/src/messages/aggregate/get.ts
+++ b/src/messages/aggregate/get.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { DEFAULT_API_V2 } from "../../global";
+import { getSocketPath, stripTrailingSlash } from "../../utils/url";
 
 type AggregateGetResponse<T> = {
     data: T;
@@ -25,11 +26,15 @@ export async function Get<T>(
     },
 ): Promise<T> {
     const _keys = keys.length === 0 ? null : keys.join(",");
-    const response = await axios.get<AggregateGetResponse<T>>(`${APIServer}/api/v0/aggregates/${address}.json`, {
-        params: {
-            keys: _keys,
+    const response = await axios.get<AggregateGetResponse<T>>(
+        `${stripTrailingSlash(APIServer)}/api/v0/aggregates/${address}.json`,
+        {
+            socketPath: getSocketPath(),
+            params: {
+                keys: _keys,
+            },
         },
-    });
+    );
 
     if (!response.data.data) {
         throw new Error("no aggregate found");

--- a/src/messages/create/publish.ts
+++ b/src/messages/create/publish.ts
@@ -3,6 +3,7 @@ import shajs from "sha.js";
 import { BaseMessage, ItemType } from "../message";
 import axios from "axios";
 import FormDataNode from "form-data";
+import { getSocketPath, stripTrailingSlash } from "../../utils/url";
 
 /**
  * message:         The message to update and then publish.
@@ -68,12 +69,13 @@ export async function PutContentToStorageEngine<T>(configuration: PutConfigurati
 
 async function PushToStorageEngine<T>(configuration: PushConfiguration<T>): Promise<string> {
     const response = await axios.post<PushResponse>(
-        `${configuration.APIServer}/api/v0/${configuration.storageEngine.toLowerCase()}/add_json`,
+        `${stripTrailingSlash(configuration.APIServer)}/api/v0/${configuration.storageEngine.toLowerCase()}/add_json`,
         configuration.content,
         {
             headers: {
                 "Content-Type": "application/json",
             },
+            socketPath: getSocketPath(),
         },
     );
     return response.data.hash;
@@ -91,7 +93,7 @@ export async function PushFileToStorageEngine(configuration: PushFileConfigurati
         form.append("file", configuration.file, "File");
     }
     const response = await axios.post<PushResponse>(
-        `${configuration.APIServer}/api/v0/${configuration.storageEngine.toLowerCase()}/add_file`,
+        `${stripTrailingSlash(configuration.APIServer)}/api/v0/${configuration.storageEngine.toLowerCase()}/add_file`,
         form,
         {
             headers: {
@@ -99,6 +101,7 @@ export async function PushFileToStorageEngine(configuration: PushFileConfigurati
                     ? undefined
                     : `multipart/form-data; boundary=${(form as FormDataNode).getBoundary()}`,
             },
+            socketPath: getSocketPath(),
         },
     );
     return response.data.hash;

--- a/src/messages/create/signature.ts
+++ b/src/messages/create/signature.ts
@@ -1,6 +1,7 @@
 import { BaseMessage } from "../message";
 import { Account } from "../../accounts/account";
 import axios from "axios";
+import { getSocketPath, stripTrailingSlash } from "../../utils/url";
 
 type SignAndBroadcastConfiguration = {
     message: BaseMessage;
@@ -16,8 +17,14 @@ export async function SignAndBroadcast(configuration: SignAndBroadcastConfigurat
 }
 
 async function Broadcast(configuration: BroadcastConfiguration) {
-    await axios.post(`${configuration.APIServer}/api/v0/ipfs/pubsub/pub`, {
-        topic: "ALEPH-TEST",
-        data: JSON.stringify(configuration.message),
-    });
+    await axios.post(
+        `${stripTrailingSlash(configuration.APIServer)}/api/v0/ipfs/pubsub/pub`,
+        {
+            topic: "ALEPH-TEST",
+            data: JSON.stringify(configuration.message),
+        },
+        {
+            socketPath: getSocketPath(),
+        },
+    );
 }

--- a/src/messages/post/get.ts
+++ b/src/messages/post/get.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { getSocketPath, stripTrailingSlash } from "../../utils/url";
 
 type PostGetConfiguration = {
     types: string | string[];
@@ -79,8 +80,12 @@ export async function Get<T>(configuration: PostGetConfiguration): Promise<PostQ
         params.hashes = configuration.hashes.join(",");
     }
 
-    const response = await axios.get<PostQueryResponse<T>>(`${configuration.APIServer}/api/v0/posts.json`, {
-        params,
-    });
+    const response = await axios.get<PostQueryResponse<T>>(
+        `${stripTrailingSlash(configuration.APIServer)}/api/v0/posts.json`,
+        {
+            params,
+            socketPath: getSocketPath(),
+        },
+    );
     return response.data;
 }

--- a/src/messages/store/get.ts
+++ b/src/messages/store/get.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { getSocketPath, stripTrailingSlash } from "../../utils/url";
 
 type StoreGetConfiguration = {
     fileHash: string;
@@ -12,9 +13,10 @@ type StoreGetConfiguration = {
  */
 export async function Get(configuration: StoreGetConfiguration): Promise<ArrayBuffer> {
     const response = await axios.get<ArrayBuffer>(
-        `${configuration.APIServer}/api/v0/storage/raw/${configuration.fileHash}?find`,
+        `${stripTrailingSlash(configuration.APIServer)}/api/v0/storage/raw/${configuration.fileHash}?find`,
         {
             responseType: "arraybuffer",
+            socketPath: getSocketPath(),
         },
     );
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,20 @@
+/**
+ * Strips any remaining trailing slashes or whitespaces at the end of a provided url
+ *
+ * @param  {string} url
+ */
+export function stripTrailingSlash(url: string) {
+    return url.replace(/\/*\s*$/gi, "");
+}
+
+/**
+ * Returns the content of the ALEPH_API_UNIX_SOCKET environment variable
+ * or undefined.
+ */
+export function getSocketPath() {
+    try {
+        return process?.env?.ALEPH_API_UNIX_SOCKET;
+    } catch {
+        return undefined;
+    }
+}


### PR DESCRIPTION
If the SDK is called from a VM with the `ALEPH_API_UNIX_SOCKET` env variable set, all the request to the API will be proxied via the provided socket.

closes #35 