### PR TITLE
Fix non-inline message

### DIFF
--- a/src/messages/create/publish.ts
+++ b/src/messages/create/publish.ts
@@ -57,6 +57,7 @@ export async function PutContentToStorageEngine<T>(configuration: PutConfigurati
         }
     }
     if (!configuration.inlineRequested) {
+        configuration.message.item_content = null;
         configuration.message.item_type = configuration.storageEngine;
         configuration.message.item_hash = await PushToStorageEngine<T>({
             content: configuration.content,

--- a/src/messages/message.ts
+++ b/src/messages/message.ts
@@ -120,7 +120,7 @@ export type BaseMessage = {
     size: number;
     time: number;
     item_type: ItemType;
-    item_content: string;
+    item_content: string | null;
     hash_type?: HashType;
     item_hash: string;
     content: BaseContent;

--- a/tests/accounts/ethereum.test.ts
+++ b/tests/accounts/ethereum.test.ts
@@ -104,8 +104,8 @@ describe("Ethereum accounts", () => {
         const msg = await post.Publish({
             APIServer: DEFAULT_API_V2,
             channel: "TEST",
-            inlineRequested: true,
-            storageEngine: ItemType.inline,
+            inlineRequested: false,
+            storageEngine: ItemType.storage,
             account: account,
             postType: "custom_type",
             content: content,


### PR DESCRIPTION
Make `item_content` = null rather than an empty string to avoid 422 error status.