### PR TITLE
Add Solana 'wallet-adapter' support

### DIFF
--- a/src/accounts/solana.ts
+++ b/src/accounts/solana.ts
@@ -10,7 +10,7 @@ type WalletSignature = {
     publicKey: string;
 };
 interface MessageSigner {
-    signMessage(message: Uint8Array): Promise<WalletSignature>;
+    signMessage(message: Uint8Array): Promise<WalletSignature> | Promise<Uint8Array>;
     publicKey: PublicKey;
     connected: boolean;
     connect(): Promise<void>;
@@ -55,7 +55,8 @@ export class SOLAccount extends Account {
 
         if (this.wallet) {
             const signed = await this.wallet.signMessage(buffer);
-            signature = signed.signature;
+            if (signed instanceof Uint8Array) signature = signed;
+            else signature = signed.signature;
         } else if (this.keypair) {
             signature = nacl.sign.detached(buffer, this.keypair.secretKey);
         } else {

--- a/tests/accounts/solana.test.ts
+++ b/tests/accounts/solana.test.ts
@@ -3,7 +3,7 @@ import { post, solana } from "../index";
 import { DEFAULT_API_V2 } from "../../src/global";
 
 import { Keypair } from "@solana/web3.js";
-import { phantomLikeProvider } from "../provider/solanaProvider";
+import { panthomLikeProvider, officialLikeProvider } from "../provider/solanaProvider";
 
 describe("Solana accounts", () => {
     it("should import an solana accounts using a private key", () => {
@@ -16,18 +16,23 @@ describe("Solana accounts", () => {
 
     it("should import an solana accounts using a provider", async () => {
         const randomKeypair = new Keypair();
-        const provider = new phantomLikeProvider(randomKeypair);
+        const providerPhantom = new panthomLikeProvider(randomKeypair);
+        const providerOfficial = new officialLikeProvider(randomKeypair);
         const accountSecretKey = await solana.ImportAccountFromPrivateKey(randomKeypair.secretKey);
-        const accountProvider = await solana.GetAccountFromProvider(provider);
+        const accountPhantom = await solana.GetAccountFromProvider(providerPhantom);
+        const accountOfficial = await solana.GetAccountFromProvider(providerOfficial);
 
-        expect(accountSecretKey.address).toStrictEqual(accountProvider.address);
+        expect(accountSecretKey.address).toStrictEqual(accountPhantom.address);
+        expect(accountOfficial.address).toStrictEqual(accountPhantom.address);
     });
 
     it("should get the same signed message for each account", async () => {
         const randomKeypair = new Keypair();
-        const provider = new phantomLikeProvider(randomKeypair);
+        const providerPhantom = new panthomLikeProvider(randomKeypair);
+        const providerOfficial = new officialLikeProvider(randomKeypair);
         const accountSecretKey = await solana.ImportAccountFromPrivateKey(randomKeypair.secretKey);
-        const accountProvider = await solana.GetAccountFromProvider(provider);
+        const accountPhantom = await solana.GetAccountFromProvider(providerPhantom);
+        const accountOfficial = await solana.GetAccountFromProvider(providerOfficial);
 
         const message = {
             chain: accountSecretKey.GetChain(),
@@ -44,7 +49,8 @@ describe("Solana accounts", () => {
             content: { address: accountSecretKey.address, time: 15 },
         };
 
-        expect(accountSecretKey.Sign(message)).toStrictEqual(accountProvider.Sign(message));
+        expect(accountSecretKey.Sign(message)).toStrictEqual(accountPhantom.Sign(message));
+        expect(accountOfficial.Sign(message)).toStrictEqual(accountPhantom.Sign(message));
     });
 
     it("should publish a post message correctly", async () => {

--- a/tests/provider/solanaProvider.ts
+++ b/tests/provider/solanaProvider.ts
@@ -7,7 +7,7 @@ type WalletSignature = {
     publicKey: string;
 };
 
-export class phantomLikeProvider {
+class solanaFakeProvider {
     public provider;
     public publicKey: PublicKey;
     public secretKey: Uint8Array;
@@ -23,9 +23,18 @@ export class phantomLikeProvider {
     connect(): Promise<void> {
         return this.provider.connect();
     }
+}
 
+export class panthomLikeProvider extends solanaFakeProvider {
     signMessage(message: Uint8Array): Promise<WalletSignature> {
         const signature = nacl.sign.detached(message, this.secretKey);
         return Promise.resolve({ signature: signature, publicKey: this.publicKey.toString() });
+    }
+}
+
+export class officialLikeProvider extends solanaFakeProvider {
+    signMessage(message: Uint8Array): Promise<Uint8Array> {
+        const signature = nacl.sign.detached(message, this.secretKey);
+        return Promise.resolve(signature);
     }
 }


### PR DESCRIPTION
Updating signMessage methods with a provider, to support phantom and solana-labs/wallet-adapter format