### PR TITLE
feat: Add a github action to publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,25 @@
+name: npm-publish
+on:
+    push:
+        branches:
+            - main
+jobs:
+    npm-publish:
+        name: npm-publish
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+            - name: Publish if version has been updated
+              uses: pascalgn/npm-publish-action@1.3.9
+              with: # All of theses inputs are optional
+                  tag_name: "v%s"
+                  tag_message: "v%s"
+                  create_tag: "true"
+                  commit_pattern: "^Release (\\S+)"
+                  workspace: "."
+                  publish_command: "yarn"
+                  publish_args: "--non-interactive"
+              env: # More info about the environment variables in the README
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
+                  NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings


### PR DESCRIPTION
This Github action will deploy the new package version when it detects a commit in the format `Release [version]` and if the package.json version has changed. It will also create a git tag accordingly