### PR TITLE
Release 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aleph-sdk-ts",
-    "version": "1.0.1",
+    "version": "3.0.1",
     "description": "Aleph.im Typescript SDK",
     "main": "dist/index.js",
     "files": [


### PR DESCRIPTION
First clean release of the SDK.

> Why 3.0.1 ?

Bumped from `2.2.2` and solves the version mismatches between the [package.json](https://github.com/aleph-im/aleph-sdk-ts/blob/main/package.json#L3) and the [NPM registry](https://www.npmjs.com/package/aleph-sdk-ts).