### PR TITLE
Revert "doc: Do not generate docs for internal use helpers"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     ],
     "scripts": {
         "build": "rm -rf dist/ && tsc",
-        "doc": "typedoc --excludeNotDocumented --excludeInternal --excludePrivate",
+        "doc": "typedoc",
         "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet",
         "lint:fix": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
         "prepack": "npm run test && npm run build",


### PR DESCRIPTION
Reverts aleph-im/aleph-sdk-ts#84

Does not work as root imports are undocumented