### PR TITLE
Patch aggregate queries

### DIFF
--- a/src/messages/aggregate/get.ts
+++ b/src/messages/aggregate/get.ts
@@ -10,6 +10,7 @@ type AggregateGetConfiguration = {
     APIServer?: string;
     address: string;
     keys?: Array<string>;
+    limit: number;
 };
 
 /**
@@ -18,20 +19,20 @@ type AggregateGetConfiguration = {
  *
  * @param configuration The configuration used to get the message, including the API endpoint.
  */
-export async function Get<T>(
-    { APIServer = DEFAULT_API_V2, address = "", keys = [] }: AggregateGetConfiguration = {
-        APIServer: DEFAULT_API_V2,
-        address: "",
-        keys: [],
-    },
-): Promise<T> {
-    const _keys = keys.length === 0 ? null : keys.join(",");
+export async function Get<T>({
+    APIServer = DEFAULT_API_V2,
+    address = "",
+    keys = [],
+    limit = 50,
+}: Partial<AggregateGetConfiguration>): Promise<T> {
     const response = await axios.get<AggregateGetResponse<T>>(
         `${stripTrailingSlash(APIServer)}/api/v0/aggregates/${address}.json`,
         {
             socketPath: getSocketPath(),
             params: {
-                keys: _keys,
+                keys: keys.join(","),
+                // FIXME
+                limit,
             },
         },
     );

--- a/src/messages/aggregate/get.ts
+++ b/src/messages/aggregate/get.ts
@@ -19,14 +19,12 @@ type AggregateGetConfiguration = {
  *
  * @param configuration The configuration used to get the message, including the API endpoint.
  */
-export async function Get<T>(
-    { APIServer = DEFAULT_API_V2, address = "", keys = [], limit = 50 }: AggregateGetConfiguration = {
-        APIServer: DEFAULT_API_V2,
-        address: "",
-        keys: [],
-        limit: 50,
-    },
-): Promise<T> {
+export async function Get<T>({
+    APIServer = DEFAULT_API_V2,
+    address = "",
+    keys = [],
+    limit = 50,
+}: AggregateGetConfiguration): Promise<T> {
     const response = await axios.get<AggregateGetResponse<T>>(
         `${stripTrailingSlash(APIServer)}/api/v0/aggregates/${address}.json`,
         {

--- a/src/messages/aggregate/get.ts
+++ b/src/messages/aggregate/get.ts
@@ -32,8 +32,7 @@ export async function Get<T>(
         {
             socketPath: getSocketPath(),
             params: {
-                keys: keys.join(","),
-                // FIXME
+                keys: keys.join(",") || undefined,
                 limit,
             },
         },

--- a/src/messages/aggregate/get.ts
+++ b/src/messages/aggregate/get.ts
@@ -10,7 +10,7 @@ type AggregateGetConfiguration = {
     APIServer?: string;
     address: string;
     keys?: Array<string>;
-    limit: number;
+    limit?: number;
 };
 
 /**
@@ -19,12 +19,14 @@ type AggregateGetConfiguration = {
  *
  * @param configuration The configuration used to get the message, including the API endpoint.
  */
-export async function Get<T>({
-    APIServer = DEFAULT_API_V2,
-    address = "",
-    keys = [],
-    limit = 50,
-}: Partial<AggregateGetConfiguration>): Promise<T> {
+export async function Get<T>(
+    { APIServer = DEFAULT_API_V2, address = "", keys = [], limit = 50 }: AggregateGetConfiguration = {
+        APIServer: DEFAULT_API_V2,
+        address: "",
+        keys: [],
+        limit: 50,
+    },
+): Promise<T> {
     const response = await axios.get<AggregateGetResponse<T>>(
         `${stripTrailingSlash(APIServer)}/api/v0/aggregates/${address}.json`,
         {

--- a/src/messages/post/get.ts
+++ b/src/messages/post/get.ts
@@ -65,10 +65,10 @@ export async function Get<T>(configuration: PostGetConfiguration): Promise<PostQ
         types: configuration.types,
         pagination: configuration.pagination,
         page: configuration.page,
-        refs: configuration.refs.join(","),
-        addresses: configuration.addresses.join(","),
-        tags: configuration.tags.join(","),
-        hashes: configuration.hashes.join(","),
+        refs: configuration.refs.join(",") || undefined,
+        addresses: configuration.addresses.join(",") || undefined,
+        tags: configuration.tags.join(",") || undefined,
+        hashes: configuration.hashes.join(",") || undefined,
     };
 
     const response = await axios.get<PostQueryResponse<T>>(

--- a/src/messages/post/get.ts
+++ b/src/messages/post/get.ts
@@ -65,20 +65,11 @@ export async function Get<T>(configuration: PostGetConfiguration): Promise<PostQ
         types: configuration.types,
         pagination: configuration.pagination,
         page: configuration.page,
+        refs: configuration.refs.join(","),
+        addresses: configuration.addresses.join(","),
+        tags: configuration.tags.join(","),
+        hashes: configuration.hashes.join(","),
     };
-
-    if (configuration.refs?.length > 0) {
-        params.refs = configuration.refs.join(",");
-    }
-    if (configuration.addresses?.length > 0) {
-        params.addresses = configuration.addresses.join(",");
-    }
-    if (configuration.tags?.length > 0) {
-        params.tags = configuration.tags.join(",");
-    }
-    if (configuration.hashes?.length > 0) {
-        params.hashes = configuration.hashes.join(",");
-    }
 
     const response = await axios.get<PostQueryResponse<T>>(
         `${stripTrailingSlash(configuration.APIServer)}/api/v0/posts.json`,

--- a/tests/messages/aggregate/get.test.ts
+++ b/tests/messages/aggregate/get.test.ts
@@ -2,63 +2,17 @@ import { aggregate } from "../../index";
 import { DEFAULT_API_V2 } from "../../../src/global";
 
 describe("Aggregate message retrieve test", () => {
-    it("should retrieve an existing aggregate message", async () => {
-        type T = {
-            satoshi: {
-                A: number;
-            };
-        };
-        const key = "satoshi";
-        const address = "0x629fBDA22F485720617C8f1209692484C0359D43";
-
-        const message = await aggregate.Get<T>({
-            APIServer: DEFAULT_API_V2,
-            address: address,
-            keys: [key],
-        });
-
-        const expected = {
-            A: 1,
-        };
-
-        expect(message.satoshi).toStrictEqual(expected);
-    });
-
-    it("should retrieve an existing aggregate message without specifies side params", async () => {
-        type T = {
-            satoshi: {
-                A: number;
-            };
-        };
-        const address = "0x629fBDA22F485720617C8f1209692484C0359D43";
-
-        const message = await aggregate.Get<T>({
-            address: address,
-        });
-
-        const expected = {
-            A: 1,
-        };
-
-        expect(message.satoshi).toStrictEqual(expected);
-    });
-
     it("should failed to retrieve an aggregate message", async () => {
-        type T = {
-            satoshi: {
-                A: number;
-            };
-        };
-        const key = "satoshi";
-        const address = "0x629xBDA22F485720617C8f1209692484C0358D43";
-
-        await expect(
-            aggregate.Get<T>({
+        try {
+            await aggregate.Get({
                 APIServer: DEFAULT_API_V2,
-                address: address,
-                keys: [key],
-            }),
-        ).rejects.toThrow();
+                address: "0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10",
+                keys: ["satoshi"],
+            });
+            expect(true).toStrictEqual(false);
+        } catch (e: any) {
+            expect(e.request.res.statusCode).toStrictEqual(404);
+        }
     });
 
     it("should print the CCN list correctly (testing #87)", async () => {

--- a/tests/messages/aggregate/get.test.ts
+++ b/tests/messages/aggregate/get.test.ts
@@ -60,4 +60,13 @@ describe("Aggregate message retrieve test", () => {
             }),
         ).rejects.toThrow();
     });
+
+    it("should print the CCN list correctly (testing #87)", async () => {
+        const message = await aggregate.Get({
+            address: "0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10",
+            keys: ["corechannel"],
+        });
+
+        expect(message).toHaveProperty("corechannel");
+    });
 });

--- a/tests/messages/aggregate/publish.test.ts
+++ b/tests/messages/aggregate/publish.test.ts
@@ -2,11 +2,9 @@ import { ItemType } from "../../../src/messages/message";
 import { DEFAULT_API_V2 } from "../../../src/global";
 import { aggregate, ethereum } from "../../index";
 
-const mnemonic = "exit canvas recycle vault excite battle short roof unlock limb attract device";
-
 describe("Aggregate message publish test", () => {
     it("should publish an aggregate message", async () => {
-        const account = ethereum.ImportAccountFromMnemonic(mnemonic);
+        const { account } = ethereum.NewAccount();
         const key = "satoshi";
 
         const content: { A: number } = {


### PR DESCRIPTION
Fetching aggregates without a limit parameter could return a 500 error under certain circumstances. 

Solution: Adding a hard limit to 50 in the SDK (while still adding a `limit` parameter for end user to increase it if needed)