### PR TITLE
Patch: protect aggregate test from alteration

### DIFF
--- a/tests/messages/aggregate/get.test.ts
+++ b/tests/messages/aggregate/get.test.ts
@@ -2,63 +2,17 @@ import { aggregate } from "../../index";
 import { DEFAULT_API_V2 } from "../../../src/global";
 
 describe("Aggregate message retrieve test", () => {
-    it("should retrieve an existing aggregate message", async () => {
-        type T = {
-            satoshi: {
-                A: number;
-            };
-        };
-        const key = "satoshi";
-        const address = "0x629fBDA22F485720617C8f1209692484C0359D43";
-
-        const message = await aggregate.Get<T>({
-            APIServer: DEFAULT_API_V2,
-            address: address,
-            keys: [key],
-        });
-
-        const expected = {
-            A: 1,
-        };
-
-        expect(message.satoshi).toStrictEqual(expected);
-    });
-
-    it("should retrieve an existing aggregate message without specifies side params", async () => {
-        type T = {
-            satoshi: {
-                A: number;
-            };
-        };
-        const address = "0x629fBDA22F485720617C8f1209692484C0359D43";
-
-        const message = await aggregate.Get<T>({
-            address: address,
-        });
-
-        const expected = {
-            A: 1,
-        };
-
-        expect(message.satoshi).toStrictEqual(expected);
-    });
-
     it("should failed to retrieve an aggregate message", async () => {
-        type T = {
-            satoshi: {
-                A: number;
-            };
-        };
-        const key = "satoshi";
-        const address = "0x629xBDA22F485720617C8f1209692484C0358D43";
-
-        await expect(
-            aggregate.Get<T>({
+        try {
+            await aggregate.Get({
                 APIServer: DEFAULT_API_V2,
-                address: address,
-                keys: [key],
-            }),
-        ).rejects.toThrow();
+                address: "0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10",
+                keys: ["satoshi"],
+            });
+            expect(true).toStrictEqual(false);
+        } catch (e: any) {
+            expect(e.request.res.statusCode).toStrictEqual(404);
+        }
     });
 
     it("should print the CCN list correctly (testing #87)", async () => {

--- a/tests/messages/aggregate/publish.test.ts
+++ b/tests/messages/aggregate/publish.test.ts
@@ -2,11 +2,9 @@ import { ItemType } from "../../../src/messages/message";
 import { DEFAULT_API_V2 } from "../../../src/global";
 import { aggregate, ethereum } from "../../index";
 
-const mnemonic = "exit canvas recycle vault excite battle short roof unlock limb attract device";
-
 describe("Aggregate message publish test", () => {
     it("should publish an aggregate message", async () => {
-        const account = ethereum.ImportAccountFromMnemonic(mnemonic);
+        const { account } = ethereum.NewAccount();
         const key = "satoshi";
 
         const content: { A: number } = {


### PR DESCRIPTION
Solution: Make the test's account from get aggregate random