### PR TITLE
Add Channels field for getting post message

### DIFF
--- a/src/messages/post/get.ts
+++ b/src/messages/post/get.ts
@@ -10,6 +10,7 @@ type PostGetConfiguration = {
     addresses: string[];
     tags: string[];
     hashes: string[];
+    channels?: string[];
 };
 
 type PostQueryParams = {
@@ -20,6 +21,7 @@ type PostQueryParams = {
     addresses?: string;
     tags?: string;
     hashes?: string;
+    channels?: string;
 };
 
 type PostResponse<T> = {
@@ -69,6 +71,7 @@ export async function Get<T>(configuration: PostGetConfiguration): Promise<PostQ
         addresses: configuration.addresses.join(",") || undefined,
         tags: configuration.tags.join(",") || undefined,
         hashes: configuration.hashes.join(",") || undefined,
+        channels: configuration.channels?.join(",") || undefined,
     };
 
     const response = await axios.get<PostQueryResponse<T>>(

--- a/tests/messages/post/get.test.ts
+++ b/tests/messages/post/get.test.ts
@@ -2,6 +2,26 @@ import { post } from "../../index";
 import { DEFAULT_API_V2 } from "../../../src/global";
 
 describe("Post get tests", () => {
+    it("should only get post from a specific channel", async () => {
+        const channel = "TEST";
+
+        const amends = await post.Get({
+            types: "amend",
+            APIServer: DEFAULT_API_V2,
+            pagination: 5,
+            page: 1,
+            refs: [],
+            addresses: [],
+            tags: [],
+            hashes: [],
+            channels: [channel],
+        });
+
+        amends.posts.map((post) => {
+            expect(post.channel).toStrictEqual(channel);
+        });
+    });
+
     it("should get a post with specific parameters", async () => {
         const content: { body: string } = {
             body: "New content !",
@@ -17,6 +37,7 @@ describe("Post get tests", () => {
             tags: [],
             hashes: ["dda0e27123721f83898093916c0eaa91230b98002dcbdacaefb1e06a41ad2e23"],
         });
+
         expect(amends.posts[0].content).toStrictEqual(content);
     });
 });


### PR DESCRIPTION
Feat: User can't specify channels for post fetching like in the Python SDK
Solution: Add an optional field for channel in get post.