### PR TITLE
Add delegate update for aggregate message

### DIFF
--- a/src/messages/aggregate/publish.ts
+++ b/src/messages/aggregate/publish.ts
@@ -20,6 +20,7 @@ import { SignAndBroadcast } from "../create/signature";
  */
 type AggregatePublishConfiguration<T> = {
     account: Account;
+    address?: string;
     key: string | AggregateContentKey;
     content: T;
     channel: string;
@@ -44,7 +45,7 @@ type AggregatePublishConfiguration<T> = {
 export async function Publish<T>(configuration: AggregatePublishConfiguration<T>): Promise<AggregateMessage<T>> {
     const timestamp = Date.now() / 1000;
     const content: AggregateContent<T> = {
-        address: configuration.account.address,
+        address: configuration.address ? configuration.address : configuration.account.address,
         key: configuration.key,
         time: timestamp,
         content: configuration.content,

--- a/tests/messages/aggregate/update.test.ts
+++ b/tests/messages/aggregate/update.test.ts
@@ -1,0 +1,124 @@
+import { ItemType } from "../../../src/messages/message";
+import { DEFAULT_API_V2 } from "../../../src/global";
+import { aggregate, ethereum } from "../../index";
+
+describe("Aggregate message update test", () => {
+    it("should publish and update an aggregate message", async () => {
+        const { account } = ethereum.NewAccount();
+        const key = "satoshi";
+
+        const content: { A: number } = {
+            A: 1,
+        };
+        const UpdatedContent: { A: number } = {
+            A: 10,
+        };
+
+        await aggregate.Publish({
+            account: account,
+            key: key,
+            content: content,
+            channel: "TEST",
+            APIServer: DEFAULT_API_V2,
+            inlineRequested: true,
+            storageEngine: ItemType.inline,
+        });
+
+        const updated = await aggregate.Publish({
+            account: account,
+            key: key,
+            content: UpdatedContent,
+            channel: "TEST",
+            APIServer: DEFAULT_API_V2,
+            inlineRequested: true,
+            storageEngine: ItemType.inline,
+        });
+
+        type T = {
+            satoshi: {
+                A: number;
+            };
+        };
+        const message = await aggregate.Get<T>({
+            APIServer: DEFAULT_API_V2,
+            address: account.address,
+            keys: [key],
+        });
+
+        const expected = {
+            A: 10,
+        };
+
+        expect(message.satoshi).toStrictEqual(expected);
+        expect(message.satoshi).toStrictEqual(updated.content.content);
+    });
+
+    it("should allow an delegate call update", async () => {
+        const owner = ethereum.NewAccount();
+        const guest = ethereum.NewAccount();
+
+        const key = "satoshi";
+        const content: { A: number } = {
+            A: 1,
+        };
+        const UpdatedContent: { A: number } = {
+            A: 10,
+        };
+
+        await aggregate.Publish({
+            account: owner.account,
+            key: key,
+            content: content,
+            channel: "TEST",
+            APIServer: DEFAULT_API_V2,
+            inlineRequested: true,
+            storageEngine: ItemType.inline,
+        });
+        await aggregate.Publish({
+            account: owner.account,
+            key: "security",
+            content: {
+                authorizations: [
+                    {
+                        address: guest.account.address,
+                        types: ["AGGREGATE"],
+                        aggregate_keys: [key],
+                    },
+                ],
+            },
+            channel: "security",
+            APIServer: DEFAULT_API_V2,
+            inlineRequested: true,
+            storageEngine: ItemType.inline,
+        });
+
+        const updated = await aggregate.Publish({
+            account: guest.account,
+            address: owner.account.address,
+            key: key,
+            content: UpdatedContent,
+            channel: "TEST",
+            APIServer: DEFAULT_API_V2,
+            inlineRequested: true,
+            storageEngine: ItemType.storage,
+        });
+
+        type T = {
+            satoshi: {
+                A: number;
+            };
+        };
+        const message = await aggregate.Get<T>({
+            APIServer: DEFAULT_API_V2,
+            address: owner.account.address,
+            keys: [key],
+        });
+
+        const expected = {
+            A: 10,
+        };
+
+        expect(message.satoshi).toStrictEqual(expected);
+        expect(message.satoshi).toStrictEqual(updated.content.content);
+    });
+});


### PR DESCRIPTION
Feat: User was not able to use the Security key feature from aggregate
Solution: Add an optional field to update aggregate for another user.

Usage on python: https://aleph-im.gitbook.io/aleph-client/api-resources-reference/aggregates/security-key
https://github.com/aleph-im/aleph-client/blob/5e7c2bd6003e028e427a895d0f6bd1559dbb2e5d/src/aleph_client/asynchronous.py#L205