### PR TITLE
Feat: Ethereum user can't encrypt data for another account.

### DIFF
--- a/src/accounts/ethereum.ts
+++ b/src/accounts/ethereum.ts
@@ -39,6 +39,16 @@ export class ETHAccount extends Account {
     }
 
     /**
+     * Encrypt a content for another user on the blockchain.
+     *
+     * @param delegateKey The public key that data are encrypted.
+     * @param content The content to encrypt.
+     */
+    async delegateEncrypt(delegateKey: string, content: Buffer): Promise<Buffer> {
+        return secp256k1_encrypt(delegateKey, content);
+    }
+
+    /**
      * Decrypt a given content using an ETHAccount.
      *
      * @param encryptedContent The encrypted content to decrypt.

--- a/tests/accounts/ethereum.test.ts
+++ b/tests/accounts/ethereum.test.ts
@@ -48,6 +48,23 @@ describe("Ethereum accounts", () => {
         expect(d).toStrictEqual(msg);
     });
 
+    it("Should delegate encryption for another account Ethereum account", async () => {
+        const mnemonicA = "mystery hole village office false satisfy divert cloth behave slim cloth carry";
+        const mnemonicB = "omit donor guilt push electric confirm denial clever clay cabbage game boil";
+        const accountBPublicKey =
+            "0x0455d7d2ff3dff02674bc446ec2a821508d3ef0965c9eb0adc9890fecbcc44f86731002cc98fa578c6156e8e7f11b589d2524ca9f0a9be06864592d36164ad1801";
+
+        const accountA = ethereum.ImportAccountFromMnemonic(mnemonicA);
+        const accountB = ethereum.ImportAccountFromMnemonic(mnemonicB);
+        const msg = Buffer.from("Innovation");
+
+        const c = await accountA.delegateEncrypt(accountBPublicKey, msg);
+        const d = await accountB.decrypt(c);
+
+        expect(c).not.toBe(msg);
+        expect(d).toStrictEqual(msg);
+    });
+
     it("Should encrypt and decrypt some data with a provided Ethereum account", async () => {
         const provider = new EthereumProvider({
             address: providerAddress,


### PR DESCRIPTION
Solution: Add delegateEncrypt to allow a user to encrypt data for another public key

Response to https://github.com/aleph-im/aleph-sdk-ts/issues/95