### PR TITLE
Chore (minor): Forget Publish method wasn't capitalized

### DIFF
--- a/src/messages/forget/index.ts
+++ b/src/messages/forget/index.ts
@@ -1,3 +1,3 @@
-import { publish } from "./publish";
+import { Publish } from "./publish";
 
-export { publish };
+export { Publish };

--- a/src/messages/forget/publish.ts
+++ b/src/messages/forget/publish.ts
@@ -38,7 +38,7 @@ type ForgetPublishConfiguration = {
  *
  * @param configuration The configuration used to publish the forget message.
  */
-export async function publish(configuration: ForgetPublishConfiguration): Promise<ForgetMessage> {
+export async function Publish(configuration: ForgetPublishConfiguration): Promise<ForgetMessage> {
     const timestamp = Date.now() / 1000;
     const content: ForgetContent = {
         address: configuration.account.address,

--- a/tests/messages/forget/publish.test.ts
+++ b/tests/messages/forget/publish.test.ts
@@ -22,7 +22,7 @@ describe("Forget publish tests", () => {
             content: content,
         });
 
-        const Fres = await forget.publish({
+        const Fres = await forget.Publish({
             APIServer: DEFAULT_API_V2,
             channel: "TEST",
             hashes: [res.item_hash],


### PR DESCRIPTION
All other Publish methods start with a capital letter