### PR TITLE
Use default params on Publish and Get methods

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -1,1 +1,5 @@
 export const DEFAULT_API_V2 = "https://api2.aleph.im";
+
+export type RequireAtLeastOne<T> = {
+    [K in keyof T]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<keyof T, K>>>;
+}[keyof T];


### PR DESCRIPTION
# Todo

## Get
- [ ] Use RequireAtLeastOne on `channels`, `refs`, `addresses`, `tags`
- [ ] Use default params for `page` and `pagination`
- [ ] Use the DEFAULT_API if no APIServer is provided

## Publish
- [ ] Use the DEFAULT_API if no APIServer is provided