### PR TITLE
Add default parameters to GET (post, aggregates, store)

### DIFF
--- a/src/messages/post/get.ts
+++ b/src/messages/post/get.ts
@@ -1,15 +1,16 @@
 import axios from "axios";
+import { DEFAULT_API_V2 } from "../../global";
 import { getSocketPath, stripTrailingSlash } from "../../utils/url";
 
 type PostGetConfiguration = {
     types: string | string[];
-    APIServer: string;
-    pagination: number;
-    page: number;
-    refs: string[];
-    addresses: string[];
-    tags: string[];
-    hashes: string[];
+    APIServer?: string;
+    pagination?: number;
+    page?: number;
+    refs?: string[];
+    addresses?: string[];
+    tags?: string[];
+    hashes?: string[];
     channels?: string[];
 };
 
@@ -62,24 +63,31 @@ type PostQueryResponse<T> = {
  *
  * @param configuration The configuration used to get the message, including the API endpoint.
  */
-export async function Get<T>(configuration: PostGetConfiguration): Promise<PostQueryResponse<T>> {
+export async function Get<T>({
+    types = "",
+    pagination = 50,
+    page = 1,
+    APIServer = DEFAULT_API_V2,
+    channels = [],
+    refs = [],
+    addresses = [],
+    tags = [],
+    hashes = [],
+}: PostGetConfiguration): Promise<PostQueryResponse<T>> {
     const params: PostQueryParams = {
-        types: configuration.types,
-        pagination: configuration.pagination,
-        page: configuration.page,
-        refs: configuration.refs.join(",") || undefined,
-        addresses: configuration.addresses.join(",") || undefined,
-        tags: configuration.tags.join(",") || undefined,
-        hashes: configuration.hashes.join(",") || undefined,
-        channels: configuration.channels?.join(",") || undefined,
+        types: types,
+        pagination: pagination,
+        page: page,
+        refs: refs.join(",") || undefined,
+        addresses: addresses.join(",") || undefined,
+        tags: tags.join(",") || undefined,
+        hashes: hashes.join(",") || undefined,
+        channels: channels?.join(",") || undefined,
     };
 
-    const response = await axios.get<PostQueryResponse<T>>(
-        `${stripTrailingSlash(configuration.APIServer)}/api/v0/posts.json`,
-        {
-            params,
-            socketPath: getSocketPath(),
-        },
-    );
+    const response = await axios.get<PostQueryResponse<T>>(`${stripTrailingSlash(APIServer)}/api/v0/posts.json`, {
+        params,
+        socketPath: getSocketPath(),
+    });
     return response.data;
 }

--- a/src/messages/store/get.ts
+++ b/src/messages/store/get.ts
@@ -1,9 +1,10 @@
 import axios from "axios";
+import { DEFAULT_API_V2 } from "../../global";
 import { getSocketPath, stripTrailingSlash } from "../../utils/url";
 
 type StoreGetConfiguration = {
     fileHash: string;
-    APIServer: string;
+    APIServer?: string;
 };
 
 /**
@@ -11,9 +12,9 @@ type StoreGetConfiguration = {
  *
  * @param configuration The message hash and the API Server endpoint to make the query.
  */
-export async function Get(configuration: StoreGetConfiguration): Promise<ArrayBuffer> {
+export async function Get({ fileHash = "", APIServer = DEFAULT_API_V2 }: StoreGetConfiguration): Promise<ArrayBuffer> {
     const response = await axios.get<ArrayBuffer>(
-        `${stripTrailingSlash(configuration.APIServer)}/api/v0/storage/raw/${configuration.fileHash}?find`,
+        `${stripTrailingSlash(APIServer)}/api/v0/storage/raw/${fileHash}?find`,
         {
             responseType: "arraybuffer",
             socketPath: getSocketPath(),

--- a/tests/messages/post/get.test.ts
+++ b/tests/messages/post/get.test.ts
@@ -1,5 +1,4 @@
 import { post } from "../../index";
-import { DEFAULT_API_V2 } from "../../../src/global";
 
 describe("Post get tests", () => {
     it("should only get post from a specific channel", async () => {
@@ -7,13 +6,7 @@ describe("Post get tests", () => {
 
         const amends = await post.Get({
             types: "amend",
-            APIServer: DEFAULT_API_V2,
             pagination: 5,
-            page: 1,
-            refs: [],
-            addresses: [],
-            tags: [],
-            hashes: [],
             channels: [channel],
         });
 
@@ -29,12 +22,8 @@ describe("Post get tests", () => {
 
         const amends = await post.Get({
             types: "amend",
-            APIServer: DEFAULT_API_V2,
-            pagination: 200,
-            page: 1,
             refs: ["7ffbfe7017b3f1010f2830cfa5b4391aefd78466a4300f47ab3f2645fab48cd4"],
             addresses: ["0xB68B9D4f3771c246233823ed1D3Add451055F9Ef"],
-            tags: [],
             hashes: ["dda0e27123721f83898093916c0eaa91230b98002dcbdacaefb1e06a41ad2e23"],
         });
 

--- a/tests/messages/store/get.test.ts
+++ b/tests/messages/store/get.test.ts
@@ -17,4 +17,15 @@ describe("Store message retrieval", () => {
 
         expect(got).toBe(expected);
     });
+
+    it("should retrieve a store message without an APIServer argument", async () => {
+        const response = await store.Get({
+            fileHash: "QmQkv43jguT5HLC8TPbYJi2iEmr4MgLgu4nmBoR4zjYb3L",
+        });
+
+        const got = ArraybufferToString(response);
+        const expected = "This is just a test.";
+
+        expect(got).toBe(expected);
+    });
 });


### PR DESCRIPTION
The goal is to enhance user experience by providing reasonable default arguments to the GET method. Previously, user had to manually provide empty arrays to ignore field in the message lookup. Also added the default API url as a default argument