### PR TITLE
Feat: User can't sign data for another account or public key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "aleph-sdk-ts",
-    "version": "3.0.3",
+    "version": "3.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "aleph-sdk-ts",
-            "version": "3.0.3",
+            "version": "3.1.0",
             "license": "MIT",
             "dependencies": {
                 "@cosmjs/amino": "^0.29.0",

--- a/src/accounts/account.ts
+++ b/src/accounts/account.ts
@@ -16,3 +16,19 @@ export abstract class Account {
     abstract GetChain(): Chain;
     abstract Sign(message: BaseMessage): Promise<string>;
 }
+
+/**
+ * The ECIESAccount class is used to implement protocols using secp256k1's curve.
+ * It extends the Account class by exposing an encryption publicKey and method
+ *
+ * All inherited classes of ECIESAccount must implement the encrypt methods and expose a publicKey.
+ */
+export abstract class ECIESAccount extends Account {
+    readonly publicKey: string;
+
+    protected constructor(address: string, publicKey: string) {
+        super(address);
+        this.publicKey = publicKey;
+    }
+    abstract encrypt(content: Buffer, delegateSupport?: string | ECIESAccount): Promise<Buffer>;
+}

--- a/tests/accounts/avalanche.test.ts
+++ b/tests/accounts/avalanche.test.ts
@@ -58,6 +58,24 @@ describe("Avalanche accounts", () => {
         expect(d).toStrictEqual(msg);
     });
 
+    it("Should delegate encryption for another account Avalanche account", async () => {
+        const PkeyB = "c5754d886b30da1368706e77d6c401e9c7c02f92200d33ad51622cf25dc62acd";
+
+        const accountA = await avalanche.ImportAccountFromPrivateKey(providerPrivateKey);
+        const accountB = await avalanche.ImportAccountFromPrivateKey(PkeyB);
+        const msg = Buffer.from("Innovation");
+
+        const c = await accountA.encrypt(msg, accountB);
+        const d = await accountB.decrypt(c);
+        expect(c).not.toBe(msg);
+        expect(d).toStrictEqual(msg);
+
+        const e = await accountA.encrypt(msg, accountB.publicKey);
+        const f = await accountB.decrypt(e);
+        expect(e).not.toBe(msg);
+        expect(f).toStrictEqual(d);
+    });
+
     it("Should encrypt and decrypt some data with an Avalanche account from provider", async () => {
         const provider = new EthereumProvider({
             address: providerAddress,
@@ -68,6 +86,23 @@ describe("Avalanche accounts", () => {
         const msg = Buffer.from("Laŭ Ludoviko Zamenhof bongustas freŝa ĉeĥa manĝaĵo kun spicoj");
 
         const c = await accountFromProvider.encrypt(msg);
+        const d = await accountFromProvider.decrypt(c);
+
+        expect(c).not.toBe(msg);
+        expect(d).toStrictEqual(msg);
+    });
+
+    it("Should delegate encrypt and decrypt some data with an Avalanche account from provider", async () => {
+        const provider = new EthereumProvider({
+            address: providerAddress,
+            privateKey: providerPrivateKey,
+            networkVersion: 31,
+        });
+        const accountA = await avalanche.ImportAccountFromPrivateKey(providerPrivateKey);
+        const accountFromProvider = await avalanche.GetAccountFromProvider(provider);
+        const msg = Buffer.from("Laŭ Ludoviko Zamenhof bongustas freŝa ĉeĥa manĝaĵo kun spicoj");
+
+        const c = await accountA.encrypt(msg, accountFromProvider);
         const d = await accountFromProvider.decrypt(c);
 
         expect(c).not.toBe(msg);

--- a/tests/accounts/eciesAccount.test.ts
+++ b/tests/accounts/eciesAccount.test.ts
@@ -1,0 +1,39 @@
+import { ethereum, avalanche, nuls2 } from "../index";
+
+describe("EciesAccount accounts", () => {
+    const mnemonicA = "mystery hole village office false satisfy divert cloth behave slim cloth carry";
+    const PkeyB = "c5754d886b30da1368706e77d6c401e9c7c02f92200d33ad51622cf25dc62acd";
+
+    it("Should test a ETH-AVAX message encryption", async () => {
+        const accountA = ethereum.ImportAccountFromMnemonic(mnemonicA);
+        const accountB = await avalanche.ImportAccountFromPrivateKey(PkeyB);
+        const msg = Buffer.from("Innovation");
+
+        const c = await accountA.encrypt(msg, accountB);
+        const d = await accountB.decrypt(c);
+        expect(c).not.toBe(msg);
+        expect(d).toStrictEqual(msg);
+    });
+
+    it("Should test a AVAX-ETH message encryption", async () => {
+        const accountA = await avalanche.ImportAccountFromPrivateKey(PkeyB);
+        const accountB = ethereum.ImportAccountFromMnemonic(mnemonicA);
+        const msg = Buffer.from("Innovation");
+
+        const c = await accountA.encrypt(msg, accountB);
+        const d = await accountB.decrypt(c);
+        expect(c).not.toBe(msg);
+        expect(d).toStrictEqual(msg);
+    });
+
+    it("Should test an ETH-NULS2 message encryption", async () => {
+        const accountA = ethereum.ImportAccountFromMnemonic(mnemonicA);
+        const accountB = await nuls2.ImportAccountFromPrivateKey(PkeyB);
+        const msg = Buffer.from("Innovation");
+
+        const c = await accountA.encrypt(msg, accountB);
+        const d = await accountB.decrypt(c);
+        expect(c).not.toBe(msg);
+        expect(d).toStrictEqual(msg);
+    });
+});

--- a/tests/accounts/ethereum.test.ts
+++ b/tests/accounts/ethereum.test.ts
@@ -48,6 +48,44 @@ describe("Ethereum accounts", () => {
         expect(d).toStrictEqual(msg);
     });
 
+    it("Should delegate encryption for another account Ethereum account", async () => {
+        const mnemonicA = "mystery hole village office false satisfy divert cloth behave slim cloth carry";
+        const mnemonicB = "omit donor guilt push electric confirm denial clever clay cabbage game boil";
+
+        const accountA = ethereum.ImportAccountFromMnemonic(mnemonicA);
+        const accountB = ethereum.ImportAccountFromMnemonic(mnemonicB);
+        const msg = Buffer.from("Innovation");
+
+        const c = await accountA.encrypt(msg, accountB);
+        const d = await accountB.decrypt(c);
+        expect(c).not.toBe(msg);
+        expect(d).toStrictEqual(msg);
+
+        const e = await accountA.encrypt(msg, accountB.publicKey);
+        const f = await accountB.decrypt(e);
+        expect(e).not.toBe(msg);
+        expect(f).toStrictEqual(d);
+    });
+
+    it("Should delegate encrypt and decrypt some data with a provided Ethereum account", async () => {
+        const mnemonicA = "mystery hole village office false satisfy divert cloth behave slim cloth carry";
+        const provider = new EthereumProvider({
+            address: providerAddress,
+            privateKey: providerPrivateKey,
+            networkVersion: 31,
+        });
+
+        const accountA = ethereum.ImportAccountFromMnemonic(mnemonicA);
+        const accountFromProvider = await ethereum.GetAccountFromProvider(provider);
+        const msg = Buffer.from("Innovation");
+
+        const c = await accountA.encrypt(msg, accountFromProvider);
+        const d = await accountFromProvider.decrypt(c);
+
+        expect(c).not.toBe(msg);
+        expect(d).toStrictEqual(msg);
+    });
+
     it("Should encrypt and decrypt some data with a provided Ethereum account", async () => {
         const provider = new EthereumProvider({
             address: providerAddress,

--- a/tests/accounts/nuls2.test.ts
+++ b/tests/accounts/nuls2.test.ts
@@ -77,8 +77,10 @@ describe("NULS2 accounts", () => {
     });
 
     it("Should delegate encrypt and decrypt content with NULS2", async () => {
+        const accountBPrivateKey = "de926db3012af759b4f24b5a51ef6afa397f04670f634aa4f48d4480417007f3";
+
         const accountA = await nuls2.ImportAccountFromPrivateKey(testPrivateKey);
-        const accountB = await nuls2.ImportAccountFromPrivateKey(testPrivateKey);
+        const accountB = await nuls2.ImportAccountFromPrivateKey(accountBPrivateKey);
         const msg = Buffer.from("Nuuullss2");
 
         const c = await accountA.encrypt(msg, accountB);

--- a/tests/accounts/nuls2.test.ts
+++ b/tests/accounts/nuls2.test.ts
@@ -70,9 +70,26 @@ describe("NULS2 accounts", () => {
         const account = await nuls2.ImportAccountFromPrivateKey(testPrivateKey);
         const msg = Buffer.from("Nuuullss2");
 
-        const c = account.encrypt(msg);
+        const c = await account.encrypt(msg);
         const d = account.decrypt(c);
         expect(c).not.toBe(msg);
         expect(d).toStrictEqual(msg);
+    });
+
+    it("Should delegate encrypt and decrypt content with NULS2", async () => {
+        const accountA = await nuls2.ImportAccountFromPrivateKey(testPrivateKey);
+        const accountB = await nuls2.ImportAccountFromPrivateKey(testPrivateKey);
+        const msg = Buffer.from("Nuuullss2");
+
+        const c = await accountA.encrypt(msg, accountB);
+        const d = accountB.decrypt(c);
+
+        const e = await accountA.encrypt(msg, accountB.publicKey);
+        const f = accountB.decrypt(c);
+
+        expect(c).not.toBe(msg);
+        expect(d).toStrictEqual(msg);
+        expect(e).not.toBe(msg);
+        expect(d).toStrictEqual(f);
     });
 });


### PR DESCRIPTION
Solution: Add an optional field for already existing encrypt() to target another account.

Linked to: https://github.com/aleph-im/aleph-sdk-ts/issues/95