### PR TITLE
Add Pinning feature for post message

### DIFF
--- a/src/messages/store/index.ts
+++ b/src/messages/store/index.ts
@@ -1,4 +1,5 @@
 import { Get } from "./get";
 import { Publish } from "./publish";
+import { Pin } from "./pin";
 
-export { Get, Publish };
+export { Get, Publish, Pin };

--- a/src/messages/store/pin.ts
+++ b/src/messages/store/pin.ts
@@ -1,0 +1,28 @@
+import * as base from "../../accounts/account";
+import { ItemType, StoreMessage } from "../message";
+import { Publish } from "./publish";
+import { DEFAULT_API_V2 } from "../../global";
+
+type StorePinConfiguration = {
+    channel: string;
+    account: base.Account;
+    fileHash: string;
+    storageEngine?: ItemType;
+    APIServer?: string;
+};
+
+/**
+ * Publishes a store message, containing a hash to pin an IPFS file.
+ * You also have to provide default message properties, such as the targeted channel or the account used to sign the message.
+ *
+ * @param spc The configuration used to pin the file.
+ */
+export async function Pin(spc: StorePinConfiguration): Promise<StoreMessage> {
+    return await Publish({
+        account: spc.account,
+        channel: spc.channel,
+        fileHash: spc.fileHash,
+        APIServer: spc.APIServer || DEFAULT_API_V2,
+        storageEngine: ItemType.ipfs,
+    });
+}

--- a/src/messages/store/publish.ts
+++ b/src/messages/store/publish.ts
@@ -1,12 +1,13 @@
 import * as base from "../../accounts/account";
-import { MessageType, ItemType, StoreContent, StoreMessage } from "../message";
+import { ItemType, MessageType, StoreContent, StoreMessage } from "../message";
 import { PushFileToStorageEngine, PutContentToStorageEngine } from "../create/publish";
 import { SignAndBroadcast } from "../create/signature";
 
 type StorePublishConfiguration = {
     channel: string;
     account: base.Account;
-    fileObject: Buffer | Blob;
+    fileObject?: Buffer | Blob;
+    fileHash?: string;
     storageEngine: ItemType;
     APIServer: string;
 };
@@ -18,11 +19,19 @@ type StorePublishConfiguration = {
  * @param spc The configuration used to publish a store message.
  */
 export async function Publish(spc: StorePublishConfiguration): Promise<StoreMessage> {
-    const hash = await PushFileToStorageEngine({
-        APIServer: spc.APIServer,
-        storageEngine: spc.storageEngine,
-        file: spc.fileObject,
-    });
+    if (!spc.fileObject && !spc.fileHash) throw new Error("You need to specify a File to upload or a Hash to pin.");
+    if (spc.fileObject && spc.fileHash) throw new Error("You can't pin a file and upload it at the same time.");
+    if (spc.fileHash && spc.storageEngine !== ItemType.ipfs) throw new Error("You must choose ipfs to pin file.");
+
+    const hash =
+        spc.fileHash ||
+        (await PushFileToStorageEngine({
+            APIServer: spc.APIServer,
+            storageEngine: spc.storageEngine,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            file: spc.fileObject,
+        }));
 
     const timestamp = Date.now() / 1000;
     const content: StoreContent = {

--- a/tests/messages/store/publish.test.ts
+++ b/tests/messages/store/publish.test.ts
@@ -31,4 +31,64 @@ describe("Store message publish", () => {
 
         expect(got).toBe(expected);
     });
+
+    it("should pin a file and retrieve it correctly", async () => {
+        const mnemonic = "twenty enough win warrior then fiction smoke tenant juice lift palace inherit";
+        const account = ethereum.ImportAccountFromMnemonic(mnemonic);
+        const helloWorldHash = "QmTp2hEo8eXRp6wg7jXv1BLCMh5a4F3B7buAUZNZUu772j";
+
+        const hash = await store.Pin({
+            channel: "TEST",
+            account: account,
+            fileHash: helloWorldHash,
+        });
+
+        const response = await store.Get({
+            fileHash: hash.content.item_hash,
+            APIServer: DEFAULT_API_V2,
+        });
+
+        const got = ArraybufferToString(response);
+        const expected = "hello world!";
+
+        expect(got).toBe(expected);
+    });
+
+    it("should fail to pin a file", async () => {
+        const mnemonic = "twenty enough win warrior then fiction smoke tenant juice lift palace inherit";
+        const account = ethereum.ImportAccountFromMnemonic(mnemonic);
+
+        const helloWorldHash = "QmTp2hEo8eXRp6wg7jXv1BLCMh5a4F3B7buAUZNZUu772j";
+        const fileContent = readFileSync("./tests/messages/store/testFile.txt");
+
+        await expect(
+            store.Publish({
+                channel: "TEST",
+                APIServer: DEFAULT_API_V2,
+                account: account,
+                storageEngine: ItemType.storage,
+                fileObject: fileContent,
+                fileHash: helloWorldHash,
+            }),
+        ).rejects.toThrow("You can't pin a file and upload it at the same time.");
+
+        await expect(
+            store.Publish({
+                channel: "TEST",
+                APIServer: DEFAULT_API_V2,
+                account: account,
+                storageEngine: ItemType.storage,
+                fileHash: helloWorldHash,
+            }),
+        ).rejects.toThrow("You must choose ipfs to pin file.");
+
+        await expect(
+            store.Publish({
+                channel: "TEST",
+                APIServer: DEFAULT_API_V2,
+                account: account,
+                storageEngine: ItemType.storage,
+            }),
+        ).rejects.toThrow("You need to specify a File to upload or a Hash to pin.");
+    });
 });


### PR DESCRIPTION
Feat: user didn't have the opportunity to pin IPFS hashes on Aleph without uploading them
Solution: Change Store publish to handle hashes pinning and add a new method `Pin` to simplify the process.

Reason: Comply with the [Python SDK ](https://aleph-im.gitbook.io/aleph-client/cli-reference/pin-a-file)