### PR TITLE
Fix: semver checking issue with ledger application for eth.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "@types/node-hid": "^1.3.1",
         "@types/ripemd160": "^2.0.0",
         "@types/secp256k1": "^4.0.3",
+        "@types/semver": "^7.3.13",
         "@types/sha.js": "^2.4.0",
         "@types/uuid": "^8.3.1",
         "@types/w3c-web-usb": "^1.0.6",
@@ -87,6 +88,7 @@
         "eciesjs": "^0.3.14",
         "ethers": "^5.6.4",
         "form-data": "^4.0.0",
+        "semver": "^7.3.8",
         "sha.js": "^2.4.11",
         "tweetnacl": "^1.0.3",
         "uuid": "^8.3.2"

--- a/src/accounts/providers/Ledger/ethereum.ts
+++ b/src/accounts/providers/Ledger/ethereum.ts
@@ -52,7 +52,7 @@ export async function GetAccountFromLedger(): Promise<ETHLedgerAccount> {
     const signer = new EthApp(transport);
 
     const { version } = await signer.getAppConfiguration();
-    if (semver.lt(version, "1.10.0")) {
+    if (semver.lt(version, "1.9.19")) {
         throw new Error("Outdated Ledger device firmware. PLease update");
     }
 

--- a/src/accounts/providers/Ledger/ethereum.ts
+++ b/src/accounts/providers/Ledger/ethereum.ts
@@ -1,4 +1,5 @@
 import EthApp from "@ledgerhq/hw-app-eth";
+import semver from "semver";
 
 import { Account } from "../../account";
 import { Chain, BaseMessage } from "../../../messages/message";
@@ -51,8 +52,7 @@ export async function GetAccountFromLedger(): Promise<ETHLedgerAccount> {
     const signer = new EthApp(transport);
 
     const { version } = await signer.getAppConfiguration();
-    const stripPatch = Number(version.replace(/(\w+\.\w+)\.\w+$/gi, "$1"));
-    if (stripPatch < 1.9) {
+    if (semver.lt(version, "1.10.0")) {
         throw new Error("Outdated Ledger device firmware. PLease update");
     }
 


### PR DESCRIPTION
ETH Ledger app is currently in 1.10.9 and was detected as lower than 1.9.0 by the SDK.