### PR TITLE
Allow to choose RPC endpoint with Web3 Provider

### DIFF
--- a/examples/toolshed/src/components/WalletConfig.tsx
+++ b/examples/toolshed/src/components/WalletConfig.tsx
@@ -1,7 +1,8 @@
-import { solana, ethereum, avalanche } from '../../../../src/accounts'
-import { WalletChains } from '../model/chains'
-import { dispatchAndConsume } from '../model/componentProps'
-import { Actions } from '../reducer'
+import {avalanche, ethereum, solana} from '../../../../src/accounts'
+import {WalletChains} from '../model/chains'
+import {dispatchAndConsume} from '../model/componentProps'
+import {Actions} from '../reducer'
+import {ChangeRpcParam, RpcChainType} from "../../../../src/accounts/providers/JsonRPCWallet";
 
 
 function WalletConfig({ dispatch, state } : dispatchAndConsume) {
@@ -12,14 +13,15 @@ function WalletConfig({ dispatch, state } : dispatchAndConsume) {
     : [null, null]
   )
 
-  const connectToMetamask = async () => {
+  const connectToMetamask = async (endpoint?: ChangeRpcParam) => {
     const [_account, provider] = getAccountClass();
 
     if(_account === null)
       return 
 
     try{
-      const account = await _account.GetAccountFromProvider(provider)
+      const account = endpoint ? await _account.GetAccountFromProvider(provider, endpoint) :
+          await _account.GetAccountFromProvider(provider)
       dispatch({
         type: Actions.SET_ACCOUNT,
         payload: account
@@ -32,7 +34,13 @@ function WalletConfig({ dispatch, state } : dispatchAndConsume) {
 
   return (
     <div>
-      <button onClick={connectToMetamask}>Connect to Provider</button>
+      <button onClick={async () => {await connectToMetamask()}}>Connect to Provider</button>
+      {state.selectedChain === WalletChains.Ethereum && <button style={{'marginLeft': '4px'}}
+          onClick={async () =>
+            {await connectToMetamask(RpcChainType.ETH_FLASHBOTS);
+      }}>
+        Connect to Provider (Flashbots endpoint)
+      </button> }
     </div>
   )
 }

--- a/src/accounts/avalanche.ts
+++ b/src/accounts/avalanche.ts
@@ -5,7 +5,7 @@ import { BaseMessage, Chain } from "../messages/message";
 import { decrypt as secp256k1_decrypt, encrypt as secp256k1_encrypt } from "eciesjs";
 import { KeyPair } from "avalanche/dist/apis/avm";
 import { Avalanche, BinTools, Buffer as AvaBuff } from "avalanche";
-import { JsonRPCWallet, RpcChainType } from "./providers/JsonRPCWallet";
+import { ChangeRpcParam, JsonRPCWallet, RpcChainType } from "./providers/JsonRPCWallet";
 import { BaseProviderWallet } from "./providers/BaseProviderWallet";
 import { providers } from "ethers";
 
@@ -167,11 +167,15 @@ export async function ImportAccountFromPrivateKey(privateKey: string): Promise<A
  * Get an account from a Web3 provider (ex: Metamask)
  *
  * @param  {providers.ExternalProvider} provider from metamask
+ * @param requestedRpc Use this params to change the RPC endpoint;
  */
-export async function GetAccountFromProvider(provider: providers.ExternalProvider): Promise<AvalancheAccount> {
+export async function GetAccountFromProvider(
+    provider: providers.ExternalProvider,
+    requestedRpc: ChangeRpcParam = RpcChainType.AVAX,
+): Promise<AvalancheAccount> {
     const avaxProvider = new providers.Web3Provider(provider);
     const jrw = new JsonRPCWallet(avaxProvider);
-    await jrw.changeNetwork(RpcChainType.AVAX);
+    await jrw.changeNetwork(requestedRpc);
 
     await jrw.connect();
     if (jrw.address) {

--- a/src/accounts/ethereum.ts
+++ b/src/accounts/ethereum.ts
@@ -4,7 +4,7 @@ import { ECIESAccount } from "./account";
 import { GetVerificationBuffer } from "../messages";
 import { BaseMessage, Chain } from "../messages/message";
 import { decrypt as secp256k1_decrypt, encrypt as secp256k1_encrypt } from "eciesjs";
-import { JsonRPCWallet } from "./providers/JsonRPCWallet";
+import { ChangeRpcParam, JsonRPCWallet, RpcChainType } from "./providers/JsonRPCWallet";
 import { BaseProviderWallet } from "./providers/BaseProviderWallet";
 
 import { bufferToHex } from "ethereumjs-util";
@@ -145,10 +145,15 @@ export function NewAccount(derivationPath = "m/44'/60'/0'/0/0"): { account: ETHA
  * Get an account from a Web3 provider (ex: Metamask)
  *
  * @param  {ethers.providers.ExternalProvider} provider
+ * @param requestedRpc Use this params to change the RPC endpoint;
  */
-export async function GetAccountFromProvider(provider: ethers.providers.ExternalProvider): Promise<ETHAccount> {
+export async function GetAccountFromProvider(
+    provider: ethers.providers.ExternalProvider,
+    requestedRpc: ChangeRpcParam = RpcChainType.ETH,
+): Promise<ETHAccount> {
     const ETHprovider = new ethers.providers.Web3Provider(provider);
     const jrw = new JsonRPCWallet(ETHprovider);
+    await jrw.changeNetwork(requestedRpc);
     await jrw.connect();
 
     if (jrw.address) return new ETHAccount(jrw, jrw.address, await jrw.getPublicKey());

--- a/src/accounts/providers/JsonRPCWallet.ts
+++ b/src/accounts/providers/JsonRPCWallet.ts
@@ -114,7 +114,7 @@ export class JsonRPCWallet extends BaseProviderWallet {
                 await this.provider.send("wallet_switchEthereumChain", [{ chainId: "0x1" }]);
             } else await this.provider.send("wallet_addEthereumChain", [ChainData[chainOrRpc]]);
         } else {
-            await this.provider.send("wallet_switchEthereumChain", [chainOrRpc]);
+            await this.provider.send("wallet_addEthereumChain", [chainOrRpc]);
         }
     }
 


### PR DESCRIPTION
Users could not choose a custom RPC enpoint with web3 providers

This Feature mainly concerns Metamask's users to avoid data collection with the Infura default endpoint.

Even if the data collection is done during a transaction, some people probably want to initiate their connection with another more secure endpoint.