### PR TITLE
Feat: Add wrapped protocol implementation for Matic and BSC

### DIFF
--- a/examples/toolshed/src/components/SelectProvider.tsx
+++ b/examples/toolshed/src/components/SelectProvider.tsx
@@ -21,7 +21,6 @@ export const availableKeypairs: Option[] = [
 ]
 
 export const availableWallets: Option[] = [
-  { label: 'Avalanche (via Metamask)', value: WalletChains.Avalanche },
   { label: 'Ethereum (via Metamask)', value: WalletChains.Ethereum },
   { label: 'Solana (via Phantom)', value: WalletChains.Solana },
 ]

--- a/examples/toolshed/src/components/WalletConfig.tsx
+++ b/examples/toolshed/src/components/WalletConfig.tsx
@@ -1,11 +1,27 @@
-import {avalanche, ethereum, solana} from '../../../../src/accounts'
-import {WalletChains} from '../model/chains'
-import {dispatchAndConsume} from '../model/componentProps'
-import {Actions} from '../reducer'
-import {ChangeRpcParam, RpcChainType} from "../../../../src/accounts/providers/JsonRPCWallet";
+import { avalanche, ethereum, solana } from '../../../../src/accounts'
+import { WalletChains } from '../model/chains'
+import { dispatchAndConsume } from '../model/componentProps'
+import { Actions } from '../reducer'
+import { RpcChainType } from "../../../../src/accounts/providers/JsonRPCWallet";
+import Select, { SingleValue } from "react-select";
+import { useState } from "react";
 
+type Option = {
+  readonly label: string
+  readonly value: number
+  readonly isDisabled?: boolean
+}
+
+const availableChains: Option[] = [
+  { label: 'Ethereum Mainnet', value: RpcChainType.ETH },
+  { label: 'Ethereum Mainnet (FLASHBOT)', value: RpcChainType.ETH_FLASHBOTS },
+  { label: 'Avalanche Mainnet', value: RpcChainType.AVAX },
+  { label: 'Polygon Mainnet', value: RpcChainType.POLYGON },
+  { label: 'BSC Mainnet', value: RpcChainType.BSC },
+]
 
 function WalletConfig({ dispatch, state } : dispatchAndConsume) {
+  const [customEndpoint, setCustomEndpoint] = useState<RpcChainType>(availableChains[0].value)
   const getAccountClass = () => (
     state.selectedChain === WalletChains.Avalanche ? [avalanche, window.ethereum]
     : state.selectedChain === WalletChains.Ethereum ? [ethereum, window.ethereum]
@@ -13,14 +29,14 @@ function WalletConfig({ dispatch, state } : dispatchAndConsume) {
     : [null, null]
   )
 
-  const connectToMetamask = async (endpoint?: ChangeRpcParam) => {
+  const connectToMetamask = async () => {
     const [_account, provider] = getAccountClass();
 
     if(_account === null)
       return 
 
     try{
-      const account = endpoint ? await _account.GetAccountFromProvider(provider, endpoint) :
+      const account = state.selectedChain === WalletChains.Ethereum ? await _account.GetAccountFromProvider(provider, customEndpoint) :
           await _account.GetAccountFromProvider(provider)
       dispatch({
         type: Actions.SET_ACCOUNT,
@@ -32,15 +48,23 @@ function WalletConfig({ dispatch, state } : dispatchAndConsume) {
     }
   }
 
+  const handleChange = (x: SingleValue<Option> ) => {
+    if (!!x) setCustomEndpoint(x.value);
+  }
+
   return (
-    <div>
-      <button onClick={async () => {await connectToMetamask()}}>Connect to Provider</button>
-      {state.selectedChain === WalletChains.Ethereum && <button style={{'marginLeft': '4px'}}
-          onClick={async () =>
-            {await connectToMetamask(RpcChainType.ETH_FLASHBOTS);
-      }}>
-        Connect to Provider (Flashbots endpoint)
-      </button> }
+    <div style={{display: 'flex', gap: '12px'}}>
+      <button
+        onClick={async () => {await connectToMetamask()}}>
+        Connect to Provider
+      </button>
+      {state.selectedChain === WalletChains.Ethereum && (
+          <div>
+            <Select options={availableChains}
+                    defaultValue={availableChains[0]}
+                    onChange={handleChange} />
+          </div>
+      )}
     </div>
   )
 }

--- a/src/accounts/providers/JsonRPCWallet.ts
+++ b/src/accounts/providers/JsonRPCWallet.ts
@@ -7,6 +7,8 @@ Encryption/Decryption features may become obsolete, for more information: https:
 export enum RpcChainType {
     ETH,
     ETH_FLASHBOTS,
+    POLYGON,
+    BSC,
     AVAX,
 }
 
@@ -57,6 +59,28 @@ const ChainData: { [key: string]: RpcType } = {
             decimals: 18,
         },
         blockExplorerUrls: ["https://etherscan.io"],
+    },
+    [RpcChainType.POLYGON]: {
+        chainId: "0x89",
+        rpcUrls: ["https://polygon-rpc.com/"],
+        chainName: "Polygon Mainnet",
+        nativeCurrency: {
+            name: "MATIC",
+            symbol: "MATIC",
+            decimals: 18,
+        },
+        blockExplorerUrls: ["https://polygonscan.com/"],
+    },
+    [RpcChainType.BSC]: {
+        chainId: "0x38",
+        rpcUrls: ["https://bsc-dataseed.binance.org/"],
+        chainName: "Binance Smart Chain Mainnet",
+        nativeCurrency: {
+            name: "BNB",
+            symbol: "BNB",
+            decimals: 18,
+        },
+        blockExplorerUrls: ["https://bscscan.com"],
     },
 };
 


### PR DESCRIPTION
- Add Polygon and Binance smart chain to the default Rpc endpoints list.
- Add a way to test in Toolshade protocols or endpoint swap:
    - Choose `Ethereum (Metamask)`
    - Pick the wrapped protocol of your choice
    - click on `connect provider`

Any other protocol relying on the ETH signature can be added by passing a custom RPC endpoint when initializing an Eth account.