### PR TITLE
Fix: Ask for the encryption pubKey only at the encryption time

### DIFF
--- a/src/accounts/account.ts
+++ b/src/accounts/account.ts
@@ -25,12 +25,14 @@ export abstract class Account {
  * All inherited classes of ECIESAccount must implement the encrypt methods and expose a publicKey.
  */
 export abstract class ECIESAccount extends Account {
-    readonly publicKey: string;
+    public publicKey: string | undefined;
 
-    protected constructor(address: string, publicKey: string) {
+    protected constructor(address: string, publicKey?: string) {
         super(address);
         this.publicKey = publicKey;
     }
+
+    abstract askPubKey(): Promise<void>;
     abstract encrypt(
         content: Buffer,
         delegateSupport?: string | ECIESAccount,

--- a/src/accounts/nuls2.ts
+++ b/src/accounts/nuls2.ts
@@ -38,21 +38,28 @@ export class NULS2Account extends ECIESAccount {
     }
 
     /**
+     * Ask for a Provider Account a read Access to its encryption publicKey.
+     * As NULS2 currently doesn't support instantiation through a provider, this method has no effect.
+     */
+    override async askPubKey(): Promise<void> {
+        return;
+    }
+
+    /**
      * Encrypt a content using the user's public key for a NULS2 account.
      *
      * @param content The content to encrypt.
      * @param delegateSupport Optional, if you want to encrypt data for another ECIESAccount (Can also be directly a public key)
      */
-    encrypt(content: Buffer, delegateSupport?: ECIESAccount | string): Promise<Buffer> {
-        let publicKey: string;
+    async encrypt(content: Buffer, delegateSupport?: ECIESAccount | string): Promise<Buffer> {
+        let publicKey: string | undefined;
 
         if (delegateSupport)
             publicKey = delegateSupport instanceof ECIESAccount ? delegateSupport.publicKey : delegateSupport;
         else publicKey = this.publicKey;
 
-        return new Promise((resolve) => {
-            resolve(secp256k1_encrypt(publicKey, content));
-        });
+        if (!publicKey) throw new Error("Cannot encrypt content");
+        return secp256k1_encrypt(publicKey, content);
     }
 
     /**


### PR DESCRIPTION
Refers to this issue: https://github.com/aleph-im/aleph-sdk-ts/issues/124

# Warning
This implementation might cause a breaking change, as the publicKey from ECIESAccount can be `undefined`.

# Implementation:

- Add a new  `abstract askPubKey(): Promise<void>;` inside ECIESAccount. This method can be called manually or be triggered inside the `encrypt` method.
- If a pubKey is already instanced nothing will happened when call askPubKey();
- Encrypt() will automatically call askPubKey() if an encryption for a tier is required

