### PR TITLE
Fix: Test suite should not use a plaintext mnemonic seed phrase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,9 @@ dist
 .idea
 <<<<<<< HEAD
 
+# Ephemeral Account
+tests/testAccount/ephemeralAccount.json
+
 # Documentation
 docs/
 =======

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
         "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet",
         "lint:fix": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
         "prepack": "npm run test && npm run build",
-        "test": "npm run test:jest && npm run test:auto",
+        "test": "npm run test:gen && npm run test:jest && npm run test:auto",
         "test:jest": "jest --testTimeout=1200000 --verbose --coverage",
-        "test:auto": "ts-node testsAuto/entryPoint.ts "
+        "test:auto": "ts-node testsAuto/entryPoint.ts ",
+        "test:gen": "ts-node tests/testAccount/entryPoint.ts",
+        "test:regen": "ts-node tests/testAccount/entryPoint.ts -r"
     },
     "repository": "git@github.com:aleph-im/aleph-sdk-ts.git",
     "author": "Aleph.im Team",

--- a/tests/accounts/avalanche.test.ts
+++ b/tests/accounts/avalanche.test.ts
@@ -2,10 +2,20 @@ import { avalanche, post } from "../index";
 import { DEFAULT_API_V2 } from "../../src/global";
 import { ItemType } from "../../src/messages/message";
 import { EthereumProvider } from "../providers/ethereumProvider";
+import { EphAccountList } from "../testAccount/entryPoint";
+import fs from "fs";
 
 describe("Avalanche accounts", () => {
-    const providerAddress = "0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D";
-    const providerPrivateKey = "de926db3012af759b4f24b5a51ef6afa397f04670f634aa4f48d4480417007f3";
+    let ephemeralAccount: EphAccountList;
+
+    // Import the List of Test Ephemeral test Account, throw if the list is not generated
+    beforeAll(async () => {
+        if (!fs.existsSync("./tests/testAccount/ephemeralAccount.json"))
+            throw Error("[Ephemeral Account Generation] - Error, please run: npm run test:regen");
+        ephemeralAccount = await import("../testAccount/ephemeralAccount.json");
+        if (!ephemeralAccount.avax.privateKey)
+            throw Error("[Ephemeral Account Generation] - Generated Account corrupted");
+    });
 
     it("should retrieved an avalanche keypair from an hexadecimal private key", async () => {
         const { account, privateKey } = await avalanche.NewAccount();
@@ -25,26 +35,17 @@ describe("Avalanche accounts", () => {
         await expect(fct).rejects.toThrow("Invalid private key");
     });
 
-    it("should retrieved an avalanche keypair from a base58 private key", async () => {
-        const keyPair = await avalanche.getKeyPair();
-        const hexPrivateKey = keyPair.getPrivateKey().toString("hex");
-        const cb58PrivateKey = keyPair.getPrivateKeyString();
-
-        const fromHex = await avalanche.ImportAccountFromPrivateKey(hexPrivateKey);
-        const fromCb58 = await avalanche.ImportAccountFromPrivateKey(cb58PrivateKey);
-
-        expect(fromHex.address).toBe(fromCb58.address);
-    });
-
     it("should import an ethereum accounts using a provider", async () => {
+        const { address, privateKey } = ephemeralAccount.eth;
+
         const provider = new EthereumProvider({
-            address: providerAddress,
-            privateKey: providerPrivateKey,
+            address,
+            privateKey,
             networkVersion: 31,
         });
 
         const accountFromProvider = await avalanche.GetAccountFromProvider(provider);
-        expect(accountFromProvider.address).toStrictEqual(providerAddress);
+        expect(accountFromProvider.address).toStrictEqual(address);
     });
 
     it("Should encrypt and decrypt some data with an Avalanche keypair", async () => {
@@ -59,27 +60,27 @@ describe("Avalanche accounts", () => {
     });
 
     it("Should delegate encryption for another account Avalanche account", async () => {
-        const PkeyB = "c5754d886b30da1368706e77d6c401e9c7c02f92200d33ad51622cf25dc62acd";
-
-        const accountA = await avalanche.ImportAccountFromPrivateKey(providerPrivateKey);
-        const accountB = await avalanche.ImportAccountFromPrivateKey(PkeyB);
+        const accountA = await avalanche.NewAccount();
+        const accountB = await avalanche.NewAccount();
         const msg = Buffer.from("Innovation");
 
-        const c = await accountA.encrypt(msg, accountB);
-        const d = await accountB.decrypt(c);
+        const c = await accountA.account.encrypt(msg, accountB.account.publicKey);
+        const d = await accountB.account.decrypt(c);
         expect(c).not.toBe(msg);
         expect(d).toStrictEqual(msg);
 
-        const e = await accountA.encrypt(msg, accountB.publicKey);
-        const f = await accountB.decrypt(e);
+        const e = await accountA.account.encrypt(msg, accountB.account.publicKey);
+        const f = await accountB.account.decrypt(e);
         expect(e).not.toBe(msg);
         expect(f).toStrictEqual(d);
     });
 
     it("Should encrypt and decrypt some data with an Avalanche account from provider", async () => {
+        const { address, privateKey } = ephemeralAccount.eth;
+
         const provider = new EthereumProvider({
-            address: providerAddress,
-            privateKey: providerPrivateKey,
+            address,
+            privateKey,
             networkVersion: 31,
         });
         const accountFromProvider = await avalanche.GetAccountFromProvider(provider);
@@ -93,12 +94,14 @@ describe("Avalanche accounts", () => {
     });
 
     it("Should delegate encrypt and decrypt some data with an Avalanche account from provider", async () => {
+        const { address, privateKey } = ephemeralAccount.eth;
+
         const provider = new EthereumProvider({
-            address: providerAddress,
-            privateKey: providerPrivateKey,
+            address,
+            privateKey,
             networkVersion: 31,
         });
-        const accountA = await avalanche.ImportAccountFromPrivateKey(providerPrivateKey);
+        const accountA = await avalanche.ImportAccountFromPrivateKey(ephemeralAccount.avax.privateKey);
         const accountFromProvider = await avalanche.GetAccountFromProvider(provider);
         const msg = Buffer.from("Laŭ Ludoviko Zamenhof bongustas freŝa ĉeĥa manĝaĵo kun spicoj");
 
@@ -110,9 +113,11 @@ describe("Avalanche accounts", () => {
     });
 
     it("should publish a post message correctly with an account from a provider", async () => {
+        const { address, privateKey } = ephemeralAccount.eth;
+
         const provider = new EthereumProvider({
-            address: providerAddress,
-            privateKey: providerPrivateKey,
+            address,
+            privateKey,
             networkVersion: 31,
         });
         const accountFromProvider = await avalanche.GetAccountFromProvider(provider);
@@ -147,7 +152,9 @@ describe("Avalanche accounts", () => {
     });
 
     it("should publish a post message correctly", async () => {
-        const { account } = await avalanche.NewAccount();
+        const { privateKey } = ephemeralAccount.avax;
+
+        const account = await avalanche.ImportAccountFromPrivateKey(privateKey);
         const content: { body: string } = {
             body: "This message was posted from the typescript-SDK test suite",
         };

--- a/tests/testAccount/entryPoint.ts
+++ b/tests/testAccount/entryPoint.ts
@@ -1,0 +1,49 @@
+import { createEphemeralAvax, createEphemeralEth } from "./generateAccounts";
+import fs from "fs";
+
+export type EphAccount = {
+    address: string;
+    publicKey: string;
+    privateKey: string;
+    mnemonic?: string;
+};
+
+export type EphAccountList = {
+    eth: EphAccount;
+    avax: EphAccount;
+};
+
+function displayUsage() {
+    console.log("[Ephemeral Account generation]");
+    console.log("Usage:");
+    console.log("ts-node tests/testAccount/entryPoint.ts");
+    console.log("Optional param:");
+    console.log("-r forced a generation of a new account");
+}
+
+async function main() {
+    const arg = process.argv[2];
+    if (!!arg && arg !== "-r") displayUsage();
+
+    if (!fs.existsSync("./tests/testAccount/ephemeralAccount.json") || process.argv[2] === "-r") {
+        const genFunctions = [createEphemeralEth, createEphemeralAvax];
+
+        const arrayOfEphAccounts = await Promise.all(
+            genFunctions.map(async (el: () => Promise<{ [key: string]: EphAccount }>) => await el()),
+        );
+        const listOfEphAccounts = Object.assign({}, ...arrayOfEphAccounts);
+
+        const jsonAccount = JSON.stringify(listOfEphAccounts, null, 4);
+        fs.writeFileSync("./tests/testAccount/ephemeralAccount.json", jsonAccount);
+        console.log(
+            "[Ephemeral Account generation] - An Ephemeral account was generated here: ./tests/testAccount/ephemeralAccount.json",
+        );
+    }
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.log(error);
+        process.exit(1);
+    });

--- a/tests/testAccount/generateAccounts.ts
+++ b/tests/testAccount/generateAccounts.ts
@@ -1,0 +1,29 @@
+import * as bip39 from "bip39";
+import { ethers } from "ethers";
+import { getKeyPair } from "../../src/accounts/avalanche";
+import { EphAccount } from "./entryPoint";
+
+async function createEphemeralEth(): Promise<{ eth: EphAccount }> {
+    const mnemonic = bip39.generateMnemonic();
+    const { address, publicKey, privateKey } = ethers.Wallet.fromMnemonic(mnemonic);
+    const ephemeralAccount: EphAccount = {
+        address,
+        publicKey,
+        privateKey: privateKey.substring(2),
+        mnemonic,
+    };
+    return { eth: ephemeralAccount };
+}
+
+async function createEphemeralAvax(): Promise<{ avax: EphAccount }> {
+    const keypair = await getKeyPair();
+
+    const ephemeralAccount: EphAccount = {
+        address: keypair.getAddressString(),
+        publicKey: keypair.getPublicKey().toString("hex"),
+        privateKey: keypair.getPrivateKey().toString("hex"),
+    };
+    return { avax: ephemeralAccount };
+}
+
+export { createEphemeralAvax, createEphemeralEth };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,9 +13,10 @@
     "declaration": true,
     "target": "ES6",
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "lib": [
       "dom",
-      "dom.iterable",
+      "dom.iterable"
     ]
   },
   "include": ["src"],


### PR DESCRIPTION
refer to:  https://github.com/aleph-im/aleph-sdk-ts/issues/127

# Implementation

- New folder at `tests/testAccount` 
- An `entryPoint.ts` script that can generate an `ephemeralAccount.json` file with Accounts that will be used by the test suit
- A `generateAccounts.ts` file which implements the logic of account generation.

# Note

- The generation script can be called using:
    - `ts-node tests/testAccount/entryPoint.ts` 
    - `npm run test:gen` or `npm run test:regen`
- An optional `-r` parameter can force a new generation of accounts list.

# Testing changes
- At the moment it's only planned to use these ephemeral accounts for tests that require sending messages on the Aleph network.
- For other tests (encryption, account creation, ...) that not involving interaction with the network, the newAccount() might be enough 