### PR TITLE
fix: getMessages now fails silently

### DIFF
--- a/src/messages/any/getMessage.ts
+++ b/src/messages/any/getMessage.ts
@@ -36,10 +36,9 @@ export async function GetMessage<T = BaseMessage>({
         APIServer,
     };
 
-    try {
-        const response = await GetMessages(params);
-        return response.messages[0] as unknown as T;
-    } catch {
+    const response = await GetMessages(params);
+    if (response.messages.length === 0) {
         throw new Error(`No messages found for: ${hash}`);
     }
+    return response.messages[0] as unknown as T;
 }

--- a/src/messages/any/getMessages.ts
+++ b/src/messages/any/getMessages.ts
@@ -86,6 +86,5 @@ export async function GetMessages({
         socketPath: getSocketPath(),
     });
 
-    if (response.data.messages.length > 0) return response.data;
-    throw new Error(`No messages found`);
+    return response.data;
 }

--- a/tests/messages/any/get.test.tsx
+++ b/tests/messages/any/get.test.tsx
@@ -157,11 +157,11 @@ describe("Test features from GetMessage", () => {
     });
 
     it("If a specific message does not exist, it should return an empty array", async () => {
-        await expect(
-            any.GetMessages({
-                hashes: ["w87e1e2ee2cbe88fa2923042b84b2f9c694w10005ca7dd40193838bf9bad18e12cw"],
-            }),
-        ).toHaveLength(0);
+        const msg = await any.GetMessages({
+            hashes: ["w87e1e2ee2cbe88fa2923042b84b2f9c694w10005ca7dd40193838bf9bad18e12cw"],
+        })
+
+        expect(msg.messages.length).toStrictEqual(0);
     });
 
     it("try by all message type", async () => {

--- a/tests/messages/any/get.test.tsx
+++ b/tests/messages/any/get.test.tsx
@@ -156,12 +156,12 @@ describe("Test features from GetMessage", () => {
         });
     });
 
-    it("If a specific message does not exist, it should failed", async () => {
+    it("If a specific message does not exist, it should return an empty array", async () => {
         await expect(
             any.GetMessages({
                 hashes: ["w87e1e2ee2cbe88fa2923042b84b2f9c694w10005ca7dd40193838bf9bad18e12cw"],
             }),
-        ).rejects.toThrow("No messages found");
+        ).toHaveLength(0);
     });
 
     it("try by all message type", async () => {

--- a/tests/messages/any/get.test.tsx
+++ b/tests/messages/any/get.test.tsx
@@ -159,7 +159,7 @@ describe("Test features from GetMessage", () => {
     it("If a specific message does not exist, it should return an empty array", async () => {
         const msg = await any.GetMessages({
             hashes: ["w87e1e2ee2cbe88fa2923042b84b2f9c694w10005ca7dd40193838bf9bad18e12cw"],
-        })
+        });
 
         expect(msg.messages.length).toStrictEqual(0);
     });


### PR DESCRIPTION
A query with no results is an acceptable response. If any.GetMessages has no match it still returns an empty array. It is up to the user to handle rejection (.... or not).