### PR TITLE
Fix : Cannot fetch multiple aggregate keys? 

### DIFF
--- a/src/messages/aggregate/get.ts
+++ b/src/messages/aggregate/get.ts
@@ -9,7 +9,7 @@ type AggregateGetResponse<T> = {
 type AggregateGetConfiguration = {
     APIServer?: string;
     address: string;
-    keys?: Array<string>;
+    key?: string;
     limit?: number;
 };
 
@@ -22,15 +22,15 @@ type AggregateGetConfiguration = {
 export async function Get<T>({
     APIServer = DEFAULT_API_V2,
     address = "",
-    keys = [],
     limit = 50,
+    key = undefined,
 }: AggregateGetConfiguration): Promise<T> {
     const response = await axios.get<AggregateGetResponse<T>>(
         `${stripTrailingSlash(APIServer)}/api/v0/aggregates/${address}.json`,
         {
             socketPath: getSocketPath(),
             params: {
-                keys: keys.join(",") || undefined,
+                key,
                 limit,
             },
         },

--- a/tests/messages/aggregate/get.test.ts
+++ b/tests/messages/aggregate/get.test.ts
@@ -7,7 +7,7 @@ describe("Aggregate message retrieve test", () => {
             await aggregate.Get({
                 APIServer: DEFAULT_API_V2,
                 address: "0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10",
-                keys: ["satoshi"],
+                key: "satoshi",
             });
             expect(true).toStrictEqual(false);
         } catch (e: any) {
@@ -18,7 +18,7 @@ describe("Aggregate message retrieve test", () => {
     it("should print the CCN list correctly (testing #87)", async () => {
         const message = await aggregate.Get({
             address: "0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10",
-            keys: ["corechannel"],
+            key: "corechannel",
         });
 
         expect(message).toHaveProperty("corechannel");


### PR DESCRIPTION
The API does not seem to allow fetching multiple **keys** for an AGGREGATE message. However, fetching a single works fine. This PR replaces the `keys: string[]` parameter with a `key: string` (singular) to match the API.