### PR TITLE
Limit rootfs size to not trigger message rejection

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -45,3 +45,9 @@ export type JSExecutionEnvironment = 'node' | 'browser'
 export function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
+
+export function gigabyteToMebibyte(n: number): number {
+  const mebibyte = 2 ** 20
+  const gigabyte = 10 ** 9
+  return Math.ceil((n * gigabyte) / mebibyte)
+}

--- a/packages/message/src/instance/impl.ts
+++ b/packages/message/src/instance/impl.ts
@@ -1,5 +1,5 @@
 import { Blockchain, DEFAULT_API_V2, stripTrailingSlash } from '@aleph-sdk/core'
-import { defaultResources, defaultExecutionEnvironment } from '../utils/constants'
+import { defaultResources, defaultExecutionEnvironment, MAXIMUM_DISK_SIZE } from '../utils/constants'
 import { buildInstanceMessage } from '../utils/messageBuilder'
 import { prepareAlephMessage } from '../utils/publish'
 import { broadcast } from '../utils/signature'
@@ -46,13 +46,15 @@ export class InstanceMessageClient {
       ...environment,
     }
 
+    const size_mib = mergedResources.memory * 10 > MAXIMUM_DISK_SIZE ? MAXIMUM_DISK_SIZE : mergedResources.memory * 10
+
     const rootfs = {
       parent: {
         ref: image as string,
         use_latest: true,
       },
       persistence: VolumePersistence.host,
-      size_mib: mergedResources.memory * 10,
+      size_mib,
     }
 
     const instanceContent: InstanceContent = {

--- a/packages/message/src/utils/constants.ts
+++ b/packages/message/src/utils/constants.ts
@@ -1,4 +1,5 @@
 import { FunctionEnvironment, MachineResources } from '../types'
+import { gigabyteToMebibyte } from '@aleph-sdk/core'
 
 export const defaultExecutionEnvironment: FunctionEnvironment = {
   reproducible: false,
@@ -12,3 +13,5 @@ export const defaultResources: MachineResources = {
   vcpus: 1,
   seconds: 30,
 }
+
+export const MAXIMUM_DISK_SIZE = gigabyteToMebibyte(100)


### PR DESCRIPTION
Following this function from aleph-message: https://github.com/aleph-im/aleph-message/blob/main/aleph_message/utils.py#L11