### PR TITLE
internal: reduce CPU usage in tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,4 +16,12 @@ export default {
   },
   testPathIgnorePatterns: ['<rootDir>/cypress/'],
   coverageReporters: ['text-summary', 'html'],
+  transformIgnorePatterns: ['/node_modules/'],
+  // Limit the number of workers to prevent CPU overload
+  maxWorkers: '50%',
+  // Enable caching (should be on by default, but explicitly set)
+  cache: true,
+  cacheDirectory: '<rootDir>/.jest-cache',
+  // Avoid transforming unnecessary files
+  modulePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/examples/'],
 }


### PR DESCRIPTION
Running `npm run test` uses 100% of CPUs by default, causing issues when running tests locally. Configured jest to target 50% and avoid parsing specific directories.