### PR TITLE
feat: add VmClient for CRN instance management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ docs/
 .gitsigners
 
 .DS_Store
+.worktrees

--- a/packages/client/__tests__/vmClient.test.ts
+++ b/packages/client/__tests__/vmClient.test.ts
@@ -1,0 +1,387 @@
+import { Blockchain } from '../../core/src'
+import { VmClient, VmOperation } from '../src/vmClient'
+
+// --- Mock Account ---
+
+function createMockAccount(chain: Blockchain = Blockchain.ETH) {
+  return {
+    address: '0xTestAddress1234567890',
+    getChain: () => chain,
+    sign: jest.fn().mockResolvedValue('0xmocksignature123'),
+  }
+}
+
+// --- Mock fetch ---
+
+const mockFetch = jest.fn()
+global.fetch = mockFetch as unknown as typeof fetch
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  mockFetch.mockResolvedValue({
+    status: 200,
+    text: () => Promise.resolve('OK'),
+  })
+})
+
+// --- Tests ---
+
+describe('VmClient', () => {
+  describe('constructor', () => {
+    it('should create a VmClient with account and node URL', () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+      expect(client.nodeDomain).toBe('crn.example.com')
+    })
+
+    it('should strip trailing slashes from node URL', () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com///')
+      expect(client.nodeDomain).toBe('crn.example.com')
+    })
+
+    it('should throw if node URL has no hostname', () => {
+      const account = createMockAccount()
+      expect(() => new VmClient(account, 'not-a-url')).toThrow()
+    })
+  })
+
+  describe('performOperation', () => {
+    it('should send authenticated POST request', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      const result = await client.performOperation('vm123', VmOperation.Stop)
+
+      expect(result.status).toBe(200)
+      expect(result.response).toBe('OK')
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/stop')
+      expect(options.method).toBe('POST')
+      expect(options.headers['X-SignedPubKey']).toBeDefined()
+      expect(options.headers['X-SignedOperation']).toBeDefined()
+    })
+
+    it('should include query params when provided', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.performOperation('vm123', VmOperation.Reinstall, {
+        params: { erase_volumes: 'false' },
+      })
+
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).toContain('erase_volumes=false')
+    })
+
+    it('should send JSON body when provided', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.performOperation('vm123', VmOperation.Restore, {
+        jsonData: { volume_ref: 'abc123' },
+      })
+
+      const [, options] = mockFetch.mock.calls[0]
+      expect(options.body).toBe('{"volume_ref":"abc123"}')
+      expect(options.headers['Content-Type']).toBe('application/json')
+    })
+
+    it('should use GET method when specified', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.performOperation('vm123', VmOperation.Backup, {
+        method: 'GET',
+      })
+
+      const [, options] = mockFetch.mock.calls[0]
+      expect(options.method).toBe('GET')
+    })
+
+    it('should return null status on network error', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network failure'))
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      const result = await client.performOperation('vm123', VmOperation.Stop)
+
+      expect(result.status).toBeNull()
+      expect(result.response).toContain('Network failure')
+    })
+  })
+
+  describe('instance lifecycle', () => {
+    it('stopInstance should POST to stop', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.stopInstance('vm123')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/stop')
+      expect(options.method).toBe('POST')
+    })
+
+    it('rebootInstance should POST to reboot', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.rebootInstance('vm123')
+
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/reboot')
+    })
+
+    it('eraseInstance should POST to erase', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.eraseInstance('vm123')
+
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/erase')
+    })
+
+    it('expireInstance should POST to expire', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.expireInstance('vm123')
+
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/expire')
+    })
+
+    it('startInstance should POST to allocation notify', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.startInstance('vm123')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toBe('https://crn.example.com/control/allocation/notify')
+      expect(options.method).toBe('POST')
+      expect(JSON.parse(options.body)).toEqual({ instance: 'vm123' })
+    })
+  })
+
+  describe('reinstallInstance', () => {
+    it('should POST to reinstall without params by default', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.reinstallInstance('vm123')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/reinstall')
+      expect(url).not.toContain('erase_volumes')
+      expect(options.method).toBe('POST')
+    })
+
+    it('should add erase_volumes=false when eraseVolumes is false', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.reinstallInstance('vm123', false)
+
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).toContain('erase_volumes=false')
+    })
+
+    it('should not add erase_volumes param when eraseVolumes is true', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.reinstallInstance('vm123', true)
+
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).not.toContain('erase_volumes')
+    })
+  })
+
+  describe('backup operations', () => {
+    it('createBackup should POST to backup', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.createBackup('vm123')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/backup')
+      expect(options.method).toBe('POST')
+    })
+
+    it('createBackup should include options as query params', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.createBackup('vm123', {
+        includeVolumes: true,
+        skipFsfreeze: true,
+      })
+
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).toContain('include_volumes=true')
+      expect(url).toContain('skip_fsfreeze=true')
+    })
+
+    it('getBackup should GET backup info', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.getBackup('vm123')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/backup')
+      expect(options.method).toBe('GET')
+    })
+
+    it('deleteBackup should DELETE specific backup', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.deleteBackup('vm123', 'backup-abc_123')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/backup/backup-abc_123')
+      expect(options.method).toBe('DELETE')
+    })
+
+    it('deleteBackup should reject invalid backup IDs', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await expect(
+        client.deleteBackup('vm123', '../etc/passwd'),
+      ).rejects.toThrow('Invalid backup ID format')
+    })
+  })
+
+  describe('restore operations', () => {
+    it('restoreFromVolume should POST with volume_ref JSON body', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.restoreFromVolume('vm123', 'volume-hash-abc')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/restore')
+      expect(options.method).toBe('POST')
+      expect(JSON.parse(options.body)).toEqual({ volume_ref: 'volume-hash-abc' })
+    })
+
+    it('restoreFromFile should POST multipart form data', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      const fakeData = Buffer.from('fake rootfs data')
+      await client.restoreFromFile('vm123', fakeData)
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/restore')
+      expect(options.method).toBe('POST')
+      expect(options.body).toBeInstanceOf(FormData)
+    })
+
+    it('getRestoreEndpoint should return URL and headers', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      const endpoint = await client.getRestoreEndpoint('vm123')
+
+      expect(endpoint.url).toContain('/control/machine/vm123/restore')
+      expect(endpoint.headers['X-SignedPubKey']).toBeDefined()
+      expect(endpoint.headers['X-SignedOperation']).toBeDefined()
+    })
+  })
+
+  describe('authentication headers', () => {
+    it('should produce valid X-SignedPubKey header', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.stopInstance('vm123')
+
+      const [, options] = mockFetch.mock.calls[0]
+      const pubkeyHeader = JSON.parse(options.headers['X-SignedPubKey'])
+
+      expect(pubkeyHeader.sender).toBe('0xTestAddress1234567890')
+      expect(pubkeyHeader.payload).toBeDefined()
+      expect(pubkeyHeader.signature).toBe('0xmocksignature123')
+      expect(pubkeyHeader.content.domain).toBe('crn.example.com')
+
+      // Verify the payload decodes to valid JSON with expected fields
+      const payloadJson = JSON.parse(
+        Buffer.from(pubkeyHeader.payload, 'hex').toString(),
+      )
+      expect(payloadJson.pubkey).toBeDefined()
+      expect(payloadJson.alg).toBe('ECDSA')
+      expect(payloadJson.domain).toBe('crn.example.com')
+      expect(payloadJson.address).toBe('0xTestAddress1234567890')
+      expect(payloadJson.chain).toBe('ETH')
+      expect(payloadJson.expires).toBeDefined()
+    })
+
+    it('should produce valid X-SignedOperation header', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.stopInstance('vm123')
+
+      const [, options] = mockFetch.mock.calls[0]
+      const opHeader = JSON.parse(options.headers['X-SignedOperation'])
+
+      expect(opHeader.payload).toBeDefined()
+      expect(opHeader.signature).toBeDefined()
+
+      // Verify the payload decodes to valid control payload
+      const payloadJson = JSON.parse(
+        Buffer.from(opHeader.payload, 'hex').toString(),
+      )
+      expect(payloadJson.time).toBeDefined()
+      expect(payloadJson.method).toBe('POST')
+      expect(payloadJson.path).toBe('/control/machine/vm123/stop')
+      expect(payloadJson.domain).toBe('crn.example.com')
+    })
+
+    it('should reuse pubkey header across requests', async () => {
+      const account = createMockAccount()
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.stopInstance('vm1')
+      await client.rebootInstance('vm2')
+
+      // account.sign should only be called once (for pubkey header)
+      expect(account.sign).toHaveBeenCalledTimes(1)
+
+      // Both requests should have the same X-SignedPubKey
+      const header1 = mockFetch.mock.calls[0][1].headers['X-SignedPubKey']
+      const header2 = mockFetch.mock.calls[1][1].headers['X-SignedPubKey']
+      expect(header1).toBe(header2)
+    })
+
+    it('should set chain to SOL for Solana accounts', async () => {
+      const account = createMockAccount(Blockchain.SOL)
+      // SOL accounts return JSON signature format
+      account.sign.mockResolvedValue(
+        JSON.stringify({
+          signature: '11111111111111111111111111111111',
+          publicKey: 'SolPubKey123',
+        }),
+      )
+      const client = new VmClient(account, 'https://crn.example.com')
+
+      await client.stopInstance('vm123')
+
+      const [, options] = mockFetch.mock.calls[0]
+      const pubkeyHeader = JSON.parse(options.headers['X-SignedPubKey'])
+      const payloadJson = JSON.parse(
+        Buffer.from(pubkeyHeader.payload, 'hex').toString(),
+      )
+      expect(payloadJson.chain).toBe('SOL')
+    })
+  })
+})

--- a/packages/client/__tests__/vmClient.test.ts
+++ b/packages/client/__tests__/vmClient.test.ts
@@ -254,9 +254,7 @@ describe('VmClient', () => {
       const account = createMockAccount()
       const client = new VmClient(account, 'https://crn.example.com')
 
-      await expect(
-        client.deleteBackup('vm123', '../etc/passwd'),
-      ).rejects.toThrow('Invalid backup ID format')
+      await expect(client.deleteBackup('vm123', '../etc/passwd')).rejects.toThrow('Invalid backup ID format')
     })
   })
 
@@ -314,9 +312,7 @@ describe('VmClient', () => {
       expect(pubkeyHeader.content.domain).toBe('crn.example.com')
 
       // Verify the payload decodes to valid JSON with expected fields
-      const payloadJson = JSON.parse(
-        Buffer.from(pubkeyHeader.payload, 'hex').toString(),
-      )
+      const payloadJson = JSON.parse(Buffer.from(pubkeyHeader.payload, 'hex').toString())
       expect(payloadJson.pubkey).toBeDefined()
       expect(payloadJson.alg).toBe('ECDSA')
       expect(payloadJson.domain).toBe('crn.example.com')
@@ -338,9 +334,7 @@ describe('VmClient', () => {
       expect(opHeader.signature).toBeDefined()
 
       // Verify the payload decodes to valid control payload
-      const payloadJson = JSON.parse(
-        Buffer.from(opHeader.payload, 'hex').toString(),
-      )
+      const payloadJson = JSON.parse(Buffer.from(opHeader.payload, 'hex').toString())
       expect(payloadJson.time).toBeDefined()
       expect(payloadJson.method).toBe('POST')
       expect(payloadJson.path).toBe('/control/machine/vm123/stop')
@@ -378,9 +372,7 @@ describe('VmClient', () => {
 
       const [, options] = mockFetch.mock.calls[0]
       const pubkeyHeader = JSON.parse(options.headers['X-SignedPubKey'])
-      const payloadJson = JSON.parse(
-        Buffer.from(pubkeyHeader.payload, 'hex').toString(),
-      )
+      const payloadJson = JSON.parse(Buffer.from(pubkeyHeader.payload, 'hex').toString())
       expect(payloadJson.chain).toBe('SOL')
     })
   })

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,2 +1,3 @@
 export * from './httpClient'
 export * from './authenticatedHttpClient'
+export * from './vmClient'

--- a/packages/client/src/vmClient.ts
+++ b/packages/client/src/vmClient.ts
@@ -1,0 +1,455 @@
+import { Account } from '@aleph-sdk/account'
+import { Blockchain } from '@aleph-sdk/core'
+import {
+  generateKeyPairSync,
+  sign as cryptoSign,
+  KeyObject,
+} from 'node:crypto'
+
+// --- Types ---
+
+export enum VmOperation {
+  Stop = 'stop',
+  Reboot = 'reboot',
+  Erase = 'erase',
+  Expire = 'expire',
+  Reinstall = 'reinstall',
+  Backup = 'backup',
+  Restore = 'restore',
+  StreamLogs = 'stream_logs',
+}
+
+export type VmOperationResult = {
+  status: number | null
+  response: string
+}
+
+// --- Base58 decoder (for Solana signature conversion) ---
+
+const BASE58_ALPHABET =
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+function base58Decode(input: string): Uint8Array {
+  if (input.length === 0) return new Uint8Array(0)
+
+  const bytes = [0]
+  for (const char of input) {
+    const value = BASE58_ALPHABET.indexOf(char)
+    if (value < 0) throw new Error(`Invalid base58 character: ${char}`)
+
+    let carry = value
+    for (let j = 0; j < bytes.length; j++) {
+      carry += bytes[j] * 58
+      bytes[j] = carry & 0xff
+      carry >>= 8
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff)
+      carry >>= 8
+    }
+  }
+
+  let leadingZeros = 0
+  for (const char of input) {
+    if (char !== '1') break
+    leadingZeros++
+  }
+
+  const result = new Uint8Array(leadingZeros + bytes.length)
+  const reversed = bytes.reverse()
+  result.set(reversed, leadingZeros)
+  return result
+}
+
+// --- VmClient ---
+
+/**
+ * Client for managing VM instances on Aleph CRN (Compute Resource Node)
+ * endpoints. Provides authenticated access to instance lifecycle operations
+ * including start, stop, reboot, erase, reinstall, backup, and restore.
+ *
+ * Authentication uses a two-header scheme:
+ * - X-SignedPubKey: ephemeral P-256 public key signed by wallet (24h validity)
+ * - X-SignedOperation: per-request payload signed by ephemeral key (ES256)
+ */
+export class VmClient {
+  private readonly account: Account
+  private readonly nodeUrl: string
+  private readonly ephemeralPublicKey: KeyObject
+  private readonly ephemeralPrivateKey: KeyObject
+  private readonly pubkeyPayload: Record<string, unknown>
+  private pubkeySignatureHeader: string | null = null
+
+  constructor(account: Account, nodeUrl: string) {
+    this.account = account
+    this.nodeUrl = nodeUrl.replace(/\/+$/, '')
+
+    const { publicKey, privateKey } = generateKeyPairSync('ec', {
+      namedCurve: 'P-256',
+    })
+    this.ephemeralPublicKey = publicKey
+    this.ephemeralPrivateKey = privateKey
+    this.pubkeyPayload = this.buildPubkeyPayload()
+  }
+
+  get nodeDomain(): string {
+    const url = new URL(this.nodeUrl)
+    if (!url.hostname) {
+      throw new Error('Could not parse node domain from URL')
+    }
+    return url.hostname
+  }
+
+  // --- Authentication internals ---
+
+  private buildPubkeyPayload(): Record<string, unknown> {
+    const jwk = this.ephemeralPublicKey.export({ format: 'jwk' })
+    const expires = new Date(Date.now() + 24 * 60 * 60 * 1000)
+
+    return {
+      pubkey: jwk,
+      alg: 'ECDSA',
+      domain: this.nodeDomain,
+      address: this.account.address,
+      expires: expires.toISOString(),
+      chain: this.account.getChain() === Blockchain.SOL ? 'SOL' : 'ETH',
+    }
+  }
+
+  private async ensurePubkeyHeader(): Promise<string> {
+    if (!this.pubkeySignatureHeader) {
+      this.pubkeySignatureHeader =
+        await this.buildPubkeySignatureHeader()
+    }
+    return this.pubkeySignatureHeader
+  }
+
+  /**
+   * Build the X-SignedPubKey header value. The pubkey payload is hex-encoded
+   * and signed with the user's wallet key. ETH uses EIP-191 signing over
+   * the original JSON bytes; SOL signs the hex string bytes directly.
+   */
+  private async buildPubkeySignatureHeader(): Promise<string> {
+    const jsonString = JSON.stringify(this.pubkeyPayload)
+    const hexPayload = Buffer.from(jsonString).toString('hex')
+    const isSOL = this.account.getChain() === Blockchain.SOL
+
+    const signable = {
+      time: 0,
+      sender: this.account.address,
+      getVerificationBuffer: () =>
+        isSOL ? Buffer.from(hexPayload) : Buffer.from(jsonString),
+    }
+
+    const rawSignature = await this.account.sign(signable)
+    const signature = isSOL
+      ? this.convertSolSignatureToHex(rawSignature)
+      : rawSignature
+
+    return JSON.stringify({
+      sender: this.account.address,
+      payload: hexPayload,
+      signature,
+      content: { domain: this.nodeDomain },
+    })
+  }
+
+  private convertSolSignatureToHex(jsonSignature: string): string {
+    const parsed = JSON.parse(jsonSignature) as {
+      signature: string
+      publicKey: string
+    }
+    const bytes = base58Decode(parsed.signature)
+    return '0x' + Buffer.from(bytes).toString('hex')
+  }
+
+  /**
+   * Sign a control payload with the ephemeral key using ES256
+   * (ECDSA P-256 + SHA-256, IEEE P1363 format).
+   */
+  private signControlPayload(
+    payload: Record<string, string>,
+  ): string {
+    const payloadBytes = Buffer.from(JSON.stringify(payload))
+    const signature = cryptoSign('SHA256', payloadBytes, {
+      key: this.ephemeralPrivateKey,
+      dsaEncoding: 'ieee-p1363',
+    })
+
+    return JSON.stringify({
+      payload: payloadBytes.toString('hex'),
+      signature: signature.toString('hex'),
+    })
+  }
+
+  private buildControlPayload(
+    vmId: string,
+    operation: string,
+    method: string,
+  ): Record<string, string> {
+    return {
+      time: new Date().toISOString(),
+      method: method.toUpperCase(),
+      path: `/control/machine/${vmId}/${operation}`,
+      domain: this.nodeDomain,
+    }
+  }
+
+  /**
+   * Build authenticated URL and headers for a CRN operation.
+   * Useful for custom requests (e.g. file uploads with progress tracking).
+   */
+  async buildHeaders(
+    vmId: string,
+    operation: string,
+    method: string,
+  ): Promise<{ url: string; headers: Record<string, string> }> {
+    const payload = this.buildControlPayload(vmId, operation, method)
+    const signedOperation = this.signControlPayload(payload)
+    const pubkeyHeader = await this.ensurePubkeyHeader()
+
+    return {
+      url: `${this.nodeUrl}${payload.path}`,
+      headers: {
+        'X-SignedPubKey': pubkeyHeader,
+        'X-SignedOperation': signedOperation,
+      },
+    }
+  }
+
+  // --- Generic operation ---
+
+  /**
+   * Perform an authenticated operation on a VM instance.
+   *
+   * @param vmId The item hash identifying the VM instance
+   * @param operation The operation path segment (use VmOperation or custom string)
+   * @param options Optional HTTP method, query params, and JSON body
+   */
+  async performOperation(
+    vmId: string,
+    operation: string,
+    options?: {
+      method?: string
+      params?: Record<string, string>
+      jsonData?: Record<string, unknown>
+    },
+  ): Promise<VmOperationResult> {
+    const method = options?.method ?? 'POST'
+    const { url, headers } = await this.buildHeaders(
+      vmId,
+      operation,
+      method,
+    )
+
+    const requestUrl = new URL(url)
+    if (options?.params) {
+      for (const [key, value] of Object.entries(options.params)) {
+        requestUrl.searchParams.set(key, value)
+      }
+    }
+
+    const fetchHeaders: Record<string, string> = { ...headers }
+    const fetchOptions: RequestInit = {
+      method,
+      headers: fetchHeaders,
+    }
+    if (options?.jsonData) {
+      fetchOptions.body = JSON.stringify(options.jsonData)
+      fetchHeaders['Content-Type'] = 'application/json'
+    }
+
+    try {
+      const response = await fetch(
+        requestUrl.toString(),
+        fetchOptions,
+      )
+      return {
+        status: response.status,
+        response: await response.text(),
+      }
+    } catch (error) {
+      return { status: null, response: String(error) }
+    }
+  }
+
+  // --- Instance lifecycle ---
+
+  /**
+   * Start a VM instance by notifying the CRN allocation endpoint.
+   * Unlike other operations, this does not require authenticated headers.
+   */
+  async startInstance(vmId: string): Promise<VmOperationResult> {
+    try {
+      const response = await fetch(
+        `${this.nodeUrl}/control/allocation/notify`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ instance: vmId }),
+        },
+      )
+      return {
+        status: response.status,
+        response: await response.text(),
+      }
+    } catch (error) {
+      return { status: null, response: String(error) }
+    }
+  }
+
+  async stopInstance(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Stop)
+  }
+
+  async rebootInstance(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Reboot)
+  }
+
+  async eraseInstance(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Erase)
+  }
+
+  async expireInstance(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Expire)
+  }
+
+  // --- Reinstall ---
+
+  /**
+   * Reinstall a VM instance to its original initial state.
+   *
+   * @param vmId The item hash identifying the VM instance
+   * @param eraseVolumes Whether to erase persistent volumes (default: true)
+   */
+  async reinstallInstance(
+    vmId: string,
+    eraseVolumes = true,
+  ): Promise<VmOperationResult> {
+    const params = eraseVolumes
+      ? undefined
+      : { erase_volumes: 'false' }
+    return this.performOperation(vmId, VmOperation.Reinstall, {
+      params,
+    })
+  }
+
+  // --- Backup ---
+
+  /**
+   * Create a backup of a running VM instance.
+   *
+   * @param vmId The item hash identifying the VM instance
+   * @param options.includeVolumes Include persistent volumes in the backup
+   * @param options.skipFsfreeze Skip filesystem freeze before backup
+   */
+  async createBackup(
+    vmId: string,
+    options?: {
+      includeVolumes?: boolean
+      skipFsfreeze?: boolean
+    },
+  ): Promise<VmOperationResult> {
+    const params: Record<string, string> = {}
+    if (options?.includeVolumes) params['include_volumes'] = 'true'
+    if (options?.skipFsfreeze) params['skip_fsfreeze'] = 'true'
+
+    return this.performOperation(vmId, VmOperation.Backup, {
+      params: Object.keys(params).length > 0 ? params : undefined,
+    })
+  }
+
+  /**
+   * Get backup information for a VM instance, including download links.
+   */
+  async getBackup(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Backup, {
+      method: 'GET',
+    })
+  }
+
+  /**
+   * Delete a specific backup of a VM instance.
+   *
+   * @param vmId The item hash identifying the VM instance
+   * @param backupId Alphanumeric backup identifier
+   */
+  async deleteBackup(
+    vmId: string,
+    backupId: string,
+  ): Promise<VmOperationResult> {
+    if (!/^[a-zA-Z0-9_-]+$/.test(backupId)) {
+      throw new Error(`Invalid backup ID format: ${backupId}`)
+    }
+    return this.performOperation(vmId, `backup/${backupId}`, {
+      method: 'DELETE',
+    })
+  }
+
+  // --- Restore ---
+
+  /**
+   * Restore a VM instance from an Aleph volume reference.
+   *
+   * @param vmId The item hash identifying the VM instance
+   * @param volumeRef The item hash of the volume to restore from
+   */
+  async restoreFromVolume(
+    vmId: string,
+    volumeRef: string,
+  ): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Restore, {
+      jsonData: { volume_ref: volumeRef },
+    })
+  }
+
+  /**
+   * Restore a VM instance by uploading a rootfs file (QCOW2 format).
+   *
+   * @param vmId The item hash identifying the VM instance
+   * @param rootfsData The rootfs file content as Buffer or Blob
+   */
+  async restoreFromFile(
+    vmId: string,
+    rootfsData: Buffer | Blob,
+  ): Promise<VmOperationResult> {
+    const { url, headers } = await this.buildHeaders(
+      vmId,
+      VmOperation.Restore,
+      'POST',
+    )
+
+    const formData = new FormData()
+    const blob =
+      rootfsData instanceof Blob
+        ? rootfsData
+        : new Blob([rootfsData], {
+            type: 'application/octet-stream',
+          })
+    formData.append('rootfs', blob)
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: formData,
+      })
+      return {
+        status: response.status,
+        response: await response.text(),
+      }
+    } catch (error) {
+      return { status: null, response: String(error) }
+    }
+  }
+
+  /**
+   * Get the authenticated URL and headers for a restore operation.
+   * Useful for custom upload implementations with progress tracking.
+   */
+  async getRestoreEndpoint(
+    vmId: string,
+  ): Promise<{ url: string; headers: Record<string, string> }> {
+    return this.buildHeaders(vmId, VmOperation.Restore, 'POST')
+  }
+}

--- a/packages/client/src/vmClient.ts
+++ b/packages/client/src/vmClient.ts
@@ -1,10 +1,6 @@
 import { Account } from '@aleph-sdk/account'
 import { Blockchain } from '@aleph-sdk/core'
-import {
-  generateKeyPairSync,
-  sign as cryptoSign,
-  KeyObject,
-} from 'node:crypto'
+import { generateKeyPairSync, sign as cryptoSign, KeyObject } from 'node:crypto'
 
 // --- Types ---
 
@@ -26,8 +22,7 @@ export type VmOperationResult = {
 
 // --- Base58 decoder (for Solana signature conversion) ---
 
-const BASE58_ALPHABET =
-  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
 function base58Decode(input: string): Uint8Array {
   if (input.length === 0) return new Uint8Array(0)
@@ -118,8 +113,7 @@ export class VmClient {
 
   private async ensurePubkeyHeader(): Promise<string> {
     if (!this.pubkeySignatureHeader) {
-      this.pubkeySignatureHeader =
-        await this.buildPubkeySignatureHeader()
+      this.pubkeySignatureHeader = await this.buildPubkeySignatureHeader()
     }
     return this.pubkeySignatureHeader
   }
@@ -137,14 +131,11 @@ export class VmClient {
     const signable = {
       time: 0,
       sender: this.account.address,
-      getVerificationBuffer: () =>
-        isSOL ? Buffer.from(hexPayload) : Buffer.from(jsonString),
+      getVerificationBuffer: () => (isSOL ? Buffer.from(hexPayload) : Buffer.from(jsonString)),
     }
 
     const rawSignature = await this.account.sign(signable)
-    const signature = isSOL
-      ? this.convertSolSignatureToHex(rawSignature)
-      : rawSignature
+    const signature = isSOL ? this.convertSolSignatureToHex(rawSignature) : rawSignature
 
     return JSON.stringify({
       sender: this.account.address,
@@ -167,9 +158,7 @@ export class VmClient {
    * Sign a control payload with the ephemeral key using ES256
    * (ECDSA P-256 + SHA-256, IEEE P1363 format).
    */
-  private signControlPayload(
-    payload: Record<string, string>,
-  ): string {
+  private signControlPayload(payload: Record<string, string>): string {
     const payloadBytes = Buffer.from(JSON.stringify(payload))
     const signature = cryptoSign('SHA256', payloadBytes, {
       key: this.ephemeralPrivateKey,
@@ -182,11 +171,7 @@ export class VmClient {
     })
   }
 
-  private buildControlPayload(
-    vmId: string,
-    operation: string,
-    method: string,
-  ): Record<string, string> {
+  private buildControlPayload(vmId: string, operation: string, method: string): Record<string, string> {
     return {
       time: new Date().toISOString(),
       method: method.toUpperCase(),
@@ -236,11 +221,7 @@ export class VmClient {
     },
   ): Promise<VmOperationResult> {
     const method = options?.method ?? 'POST'
-    const { url, headers } = await this.buildHeaders(
-      vmId,
-      operation,
-      method,
-    )
+    const { url, headers } = await this.buildHeaders(vmId, operation, method)
 
     const requestUrl = new URL(url)
     if (options?.params) {
@@ -260,10 +241,7 @@ export class VmClient {
     }
 
     try {
-      const response = await fetch(
-        requestUrl.toString(),
-        fetchOptions,
-      )
+      const response = await fetch(requestUrl.toString(), fetchOptions)
       return {
         status: response.status,
         response: await response.text(),
@@ -281,14 +259,11 @@ export class VmClient {
    */
   async startInstance(vmId: string): Promise<VmOperationResult> {
     try {
-      const response = await fetch(
-        `${this.nodeUrl}/control/allocation/notify`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ instance: vmId }),
-        },
-      )
+      const response = await fetch(`${this.nodeUrl}/control/allocation/notify`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ instance: vmId }),
+      })
       return {
         status: response.status,
         response: await response.text(),
@@ -322,13 +297,8 @@ export class VmClient {
    * @param vmId The item hash identifying the VM instance
    * @param eraseVolumes Whether to erase persistent volumes (default: true)
    */
-  async reinstallInstance(
-    vmId: string,
-    eraseVolumes = true,
-  ): Promise<VmOperationResult> {
-    const params = eraseVolumes
-      ? undefined
-      : { erase_volumes: 'false' }
+  async reinstallInstance(vmId: string, eraseVolumes = true): Promise<VmOperationResult> {
+    const params = eraseVolumes ? undefined : { erase_volumes: 'false' }
     return this.performOperation(vmId, VmOperation.Reinstall, {
       params,
     })
@@ -374,10 +344,7 @@ export class VmClient {
    * @param vmId The item hash identifying the VM instance
    * @param backupId Alphanumeric backup identifier
    */
-  async deleteBackup(
-    vmId: string,
-    backupId: string,
-  ): Promise<VmOperationResult> {
+  async deleteBackup(vmId: string, backupId: string): Promise<VmOperationResult> {
     if (!/^[a-zA-Z0-9_-]+$/.test(backupId)) {
       throw new Error(`Invalid backup ID format: ${backupId}`)
     }
@@ -394,10 +361,7 @@ export class VmClient {
    * @param vmId The item hash identifying the VM instance
    * @param volumeRef The item hash of the volume to restore from
    */
-  async restoreFromVolume(
-    vmId: string,
-    volumeRef: string,
-  ): Promise<VmOperationResult> {
+  async restoreFromVolume(vmId: string, volumeRef: string): Promise<VmOperationResult> {
     return this.performOperation(vmId, VmOperation.Restore, {
       jsonData: { volume_ref: volumeRef },
     })
@@ -409,15 +373,8 @@ export class VmClient {
    * @param vmId The item hash identifying the VM instance
    * @param rootfsData The rootfs file content as Buffer or Blob
    */
-  async restoreFromFile(
-    vmId: string,
-    rootfsData: Buffer | Blob,
-  ): Promise<VmOperationResult> {
-    const { url, headers } = await this.buildHeaders(
-      vmId,
-      VmOperation.Restore,
-      'POST',
-    )
+  async restoreFromFile(vmId: string, rootfsData: Buffer | Blob): Promise<VmOperationResult> {
+    const { url, headers } = await this.buildHeaders(vmId, VmOperation.Restore, 'POST')
 
     const formData = new FormData()
     const blob =
@@ -447,9 +404,7 @@ export class VmClient {
    * Get the authenticated URL and headers for a restore operation.
    * Useful for custom upload implementations with progress tracking.
    */
-  async getRestoreEndpoint(
-    vmId: string,
-  ): Promise<{ url: string; headers: Record<string, string> }> {
+  async getRestoreEndpoint(vmId: string): Promise<{ url: string; headers: Record<string, string> }> {
     return this.buildHeaders(vmId, VmOperation.Restore, 'POST')
   }
 }


### PR DESCRIPTION
## Summary

- Adds `VmClient` class to `@aleph-sdk/client` for direct interaction with Aleph CRN (Compute Resource Node) endpoints
- Implements the two-layer authentication scheme (`X-SignedPubKey` + `X-SignedOperation`) matching the Python SDK
- Supports all VM lifecycle operations: start, stop, reboot, erase, expire, **reinstall**, backup (create/get/delete), and restore (from volume or file upload)

Port of [aleph-sdk-python PR #279](https://github.com/aleph-im/aleph-sdk-python/pull/279) to TypeScript.

### Usage

```typescript
import { VmClient } from '@aleph-sdk/client'
import { importAccountFromPrivateKey } from '@aleph-sdk/ethereum'

const account = importAccountFromPrivateKey('0x...')
const client = new VmClient(account, 'https://your-crn-node.example.com')

// Reinstall VM to its original default state
await client.reinstallInstance('your-vm-item-hash')

// Reinstall but keep persistent volumes
await client.reinstallInstance('your-vm-item-hash', false)

// Backup and restore
await client.createBackup('vm-hash', { includeVolumes: true })
await client.restoreFromVolume('vm-hash', 'volume-ref-hash')
```

## Test plan

- [x] 28 unit tests covering all operations, authentication headers, query params, error handling, and path traversal prevention
- [x] Full monorepo build passes (`lerna run build` — 16 projects)
- [ ] Integration test against a live CRN node with the `/reinstall` endpoint (requires [aleph-vm PR #874](https://github.com/aleph-im/aleph-vm/pull/874))