### PR TITLE
feat(client): add browser-compatible VmClient for CRN management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,9 @@ docs/
 .gitsigners
 
 .DS_Store
+
+# Jest cache
+.jest-cache/
+
+# Git worktrees
+.worktrees/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,101 @@
+# Architecture
+
+Technical patterns and decisions for `aleph-sdk-ts`.
+
+---
+
+## Stack
+
+| Layer | Technology |
+|-------|------------|
+| Language | TypeScript (ESM + CJS dual output) |
+| Build | Rollup via Lerna monorepo |
+| Test | Jest |
+| Lint/Format | Prettier |
+| Package Manager | npm (workspaces) |
+| CI | GitHub Actions |
+
+---
+
+## Project Structure
+
+```
+packages/
+  account/       # Account abstraction (sign, address, chain)
+  client/        # HTTP + authenticated HTTP + VM client
+  core/          # Shared types (Blockchain enum, etc.)
+  ethereum/      # ETH account implementation
+  solana/        # SOL account implementation
+  avalanche/     # AVAX account
+  base/          # Base account
+  cosmos/        # Cosmos account
+  dns/           # DNS utilities
+  ethereum-ledger/ # Ledger hardware wallet
+  evm/           # Generic EVM account
+  message/       # Aleph message types
+  nuls2/         # NULS2 account
+  substrate/     # Substrate account
+  superfluid/    # Superfluid integration
+  tezos/         # Tezos account
+docs/
+  plans/         # Design docs and implementation plans
+  ARCHITECTURE.md
+  BACKLOG.md
+  DECISIONS.md
+```
+
+---
+
+## Patterns
+
+### Account Abstraction
+**Context:** SDK supports multiple blockchains with different signing schemes.
+**Approach:** All chains implement the `Account` interface from `@aleph-sdk/account` which provides `address`, `getChain()`, and `sign(signable)`. The `SignableMessage` interface uses `getVerificationBuffer(): Buffer` for chain-specific message formatting.
+**Key files:** `packages/account/src/`
+**Notes:** `Buffer` usage is forced by the `SignableMessage` interface — this is an upstream constraint. Browser bundlers (webpack, vite) typically polyfill Buffer.
+
+### VmClient CRN Authentication
+**Context:** CRN (Compute Resource Node) instances require a two-layer auth scheme.
+**Approach:** Two headers per request:
+1. `X-SignedPubKey` — ephemeral P-256 key signed by wallet (24h TTL, cached)
+2. `X-SignedOperation` — per-request ES256 signature by ephemeral key
+
+Uses Web Crypto API (`crypto.subtle`) for browser + Node.js 15+ compatibility. Static factory `VmClient.create()` because `crypto.subtle.generateKey` is async.
+
+**Key files:** `packages/client/src/vmClient.ts`, `packages/client/src/utils/hex.ts`
+**Notes:**
+- Domain field must be hostname only (not full URL) — CRN validates `domain == settings.DOMAIN_NAME`
+- All non-SOL chains normalize to `'ETH'` in the chain field
+- ETH signs raw JSON bytes; SOL signs hex-encoded payload string as UTF-8 bytes
+- SOL signatures are base58, converted to 0x-prefixed hex for the header
+
+### Hex Utilities (Browser-Safe)
+**Context:** `Buffer.from(...).toString('hex')` is Node.js specific.
+**Approach:** Minimal `Uint8Array`-based hex encoding in `packages/client/src/utils/hex.ts`. Four functions: `bytesToHex`, `hexToBytes`, `utf8ToBytes`, `bytesToUtf8`.
+**Key files:** `packages/client/src/utils/hex.ts`
+**Notes:** Only `bytesToHex` and `utf8ToBytes` are used by production code. `hexToBytes` and `bytesToUtf8` are test utilities for decoding payloads in assertions.
+
+---
+
+## Recipes
+
+### Adding a New VmClient Operation
+1. Add the operation to `VmOperation` enum if it maps to a CRN endpoint
+2. Add a method that calls `this.performOperation(vmId, VmOperation.X, options)` or uses `this.buildAuthHeaders(path, method)` for custom paths
+3. Add tests in `packages/client/__tests__/vmClient.test.ts` verifying URL, method, headers, and params
+4. Run `npx jest packages/client/__tests__/` to verify
+
+### Running Client Tests
+```bash
+npx jest packages/client/__tests__/ --no-cache
+```
+
+### Full Monorepo Build
+```bash
+npm run build
+```
+
+### Lint Check
+```bash
+npx prettier --check packages/client/src/ packages/client/__tests__/
+```

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,57 @@
+# Backlog
+
+Ideas and scope creep captured for later consideration.
+
+---
+
+## How Items Get Here
+
+- Scope drift detected during focused work (active interrupt)
+- Ideas that come up but aren't current priority
+- "We should also..." moments
+- Features identified but deferred
+
+---
+
+## Open Items
+
+### 2026-02-26 - Add streamLogs async generator tests
+**Source:** Identified during final code review of VmClient (PR #203)
+**Description:** The `streamLogs` method is the most complex in VmClient (async generator with WebSocket, message queue, error/close handling, abort signal). Currently only URL construction and header building are tested. Add tests using a mock WebSocket that exercise: normal message flow, error handling, clean close, and abort signal.
+**Priority:** Medium
+
+### 2026-02-26 - Add base58Decode standalone unit tests
+**Source:** Identified during final code review of VmClient (PR #203)
+**Description:** `base58Decode` is only exercised indirectly through SOL signing tests with trivially short input (`'2gPmh'`). Edge cases (empty input, leading zeros, invalid characters) are handled but untested. Add dedicated tests, possibly using `bs58` from `packages/solana` as a reference oracle.
+**Priority:** Low
+
+### 2026-02-26 - Add restoreFromVolume/restoreFromFile test coverage
+**Source:** Identified during final code review of VmClient (PR #203)
+**Description:** Both restore methods lack test coverage. `restoreFromFile` uses FormData which needs careful mocking.
+**Priority:** Low
+
+### 2026-02-26 - Draft front-end migration PR (front-aleph-cloud-page)
+**Source:** VmClient implementation plan — Tasks 9-11
+**Description:** Replace `ExecutableManager`'s duplicated CRN auth/VM control code (~200 lines) with `@aleph-sdk/client` VmClient. Remove `getKeyPair()`, `getAuthPubKeyToken()`, `getAuthOperationToken()`, `sendPostOperation()`, `subscribeLogs()` and related types. Cache VmClient per CRN domain in hooks. See `docs/plans/2026-02-26-vmclient-implementation.md` Tasks 9-11 for full plan.
+**Priority:** High (blocked on PR #203 merge + npm publish)
+
+### 2026-02-26 - Version bump and npm publish @aleph-sdk/client
+**Source:** VmClient implementation plan — PR #3
+**Description:** After PR #203 merges, bump version and publish `@aleph-sdk/client` to npm so the front-end can consume VmClient.
+**Priority:** High (blocked on PR #203 merge)
+
+### 2026-02-26 - Integration tests against live CRN
+**Source:** VmClient design doc
+**Description:** Run VmClient operations against a real CRN to verify auth flow end-to-end. Currently all tests use mocked fetch/crypto.
+**Priority:** Low
+
+---
+
+## Completed / Rejected
+
+<details>
+<summary>Archived items</summary>
+
+<!-- Completed items moved here with checkmark and date -->
+
+</details>

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,38 @@
+# Decisions Log
+
+Key decisions made during development. When you wonder "why did we do X?", the answer should be here.
+
+---
+
+## How Decisions Are Logged
+
+Decisions are captured when these phrases appear:
+- "decided" / "let's go with" / "rejected"
+- "choosing X because" / "not doing X because"
+- "actually, let's" / "changed my mind"
+
+Each entry includes:
+- Context (what we were working on)
+- Decision (what was chosen)
+- Rationale (why - the most important part)
+
+---
+
+## Decision #3 - 2026-02-26
+**Context:** VmClient implementation — how to handle SOL signature format
+**Decision:** Convert SOL base58 signatures to 0x-prefixed hex inline, using a minimal base58Decode implementation rather than importing `bs58`
+**Rationale:** `bs58` is available in `packages/solana` but adding a cross-package dependency for one function increases coupling. The base58 decoder is ~30 lines and only used for SOL signature conversion. Keeps the client package browser-bundle-friendly with no extra dependencies.
+**Alternatives considered:** Import `bs58` from solana package; add `bs58` as direct dependency to client package
+
+## Decision #2 - 2026-02-26
+**Context:** VmClient implementation — CRN domain field
+**Decision:** Use `new URL(nodeUrl).hostname` for the `domain` field in all auth payloads
+**Rationale:** The CRN server validates `domain == settings.DOMAIN_NAME` where `DOMAIN_NAME` is the hostname (e.g., `crn.example.com`), not the full URL. Using the full URL would cause auth rejection. The `nodeDomain` getter centralizes this.
+
+## Decision #1 - 2026-02-26
+**Context:** Making VmClient work in browsers — choosing crypto approach
+**Decision:** Use Web Crypto API (`crypto.subtle`) exclusively, no `node:crypto`
+**Rationale:** Web Crypto API is available in all modern browsers and Node.js 15+ (SDK targets Node 20+). A single code path avoids conditional logic and testing complexity. The only async change is key generation, handled cleanly by a static factory pattern.
+**Alternatives considered:**
+- Conditional `node:crypto` / `crypto.subtle` — two code paths, more complexity, marginal perf gain not worth it
+- Injectable CryptoProvider interface — over-engineered for exactly two operations (keygen + sign)

--- a/docs/plans/2026-02-26-vmclient-browser-compat-design.md
+++ b/docs/plans/2026-02-26-vmclient-browser-compat-design.md
@@ -1,0 +1,118 @@
+# VmClient Browser Compatibility & Front-End Migration
+
+Date: 2026-02-26
+
+## Problem
+
+PR #202 adds a `VmClient` class to `@aleph-sdk/client` for CRN instance management, but it uses `node:crypto` which only works in Node.js. The front-end (`front-aleph-cloud-page`) has its own duplicated implementation of the same auth scheme in `ExecutableManager`. We need the SDK's VmClient to work in browsers so the front-end can replace its duplicated code.
+
+## Scope
+
+SDK VmClient handles **CRN control plane only**:
+
+| In scope | Out of scope (stays in front-end) |
+|---|---|
+| VM lifecycle (stop/reboot/erase/expire) | PAYG stream management |
+| Backup/restore/reinstall | SSH key management |
+| Log streaming (WebSocket) | Domain management |
+| CRN resource reservation | Cost estimation |
+| Allocation notify (start) | Checkout flow orchestration |
+| Status checking | |
+
+## Approach: Web Crypto API only
+
+Replace all `node:crypto` usage with `crypto.subtle`. The Web Crypto API is available in all modern browsers and Node.js 15+. The SDK targets Node 20+, so this works everywhere with zero conditional logic.
+
+| Current (node:crypto) | New (Web Crypto API) |
+|---|---|
+| `generateKeyPairSync('ec', ...)` | `crypto.subtle.generateKey(...)` |
+| `sign('SHA256', payload, { key, dsaEncoding: 'ieee-p1363' })` | `crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, payload)` |
+| `KeyObject` types | `CryptoKey` types |
+
+Key generation becomes async, so the constructor changes to a **static factory**:
+
+```typescript
+const client = await VmClient.create(account, 'https://crn.example.com')
+```
+
+### Alternatives considered
+
+- **Conditional node:crypto / crypto.subtle:** Two code paths, more complexity, marginal perf gain not worth it.
+- **Injectable CryptoProvider interface:** Over-engineered for exactly two operations (keygen + sign).
+
+## SDK VmClient changes (vs PR #202)
+
+1. Replace `node:crypto` with `crypto.subtle`
+2. Static factory `VmClient.create()` instead of sync constructor
+3. Add `streamLogs(vmId)` — WebSocket with auth message, returns `AsyncGenerator<LogEntry>`
+4. Add `reserveResources(config)` — POST to `/control/reserve_resources` with auth headers
+5. Replace `Buffer` usage with `Uint8Array` + hex helpers where possible
+6. Update tests for async key generation
+
+### Signing correctness (verified)
+
+The signing logic in PR #202 already matches both the Python SDK and CRN server expectations:
+
+- **ETH:** EIP-191 signature over JSON string bytes (via `account.sign()`)
+- **SOL:** Direct signature over hex-encoded payload bytes (via `account.sign()`)
+- **Operations:** ES256 (ECDSA P-256 + SHA-256, IEEE P1363 format) with ephemeral key
+
+No changes needed to the signing logic itself — only the crypto primitives that generate keys and sign operation payloads.
+
+## Front-end migration
+
+### Remove from `ExecutableManager` (~200 lines)
+
+- `getKeyPair()`, `getAuthPubKeyToken()`, `getAuthOperationToken()`
+- `sendPostOperation()`
+- `subscribeLogs()`
+- `KeyPair`, `AuthPubKeyToken`, `SignedPublicKeyHeader` types
+- `KEYPAIR_TTL` constant and static `cachedPubKeyToken` cache
+
+### Keep in `ExecutableManager`
+
+- Higher-level orchestration (add/delete instances, cost, checkout steps)
+- PAYG stream management, SSH key management, domain management
+
+### Usage pattern
+
+```typescript
+// Before:
+await manager.sendPostOperation({ hostname, operation: 'stop', vmId })
+
+// After:
+const vmClient = await VmClient.create(account, nodeUrl)
+await vmClient.stopInstance(vmId)
+```
+
+VmClient instantiated in hooks (`useExecutableActions`), cached per CRN domain to reuse the pubkey header across operations.
+
+## PR sequence (strict merge order)
+
+```
+PR #1 (aleph-vm #874: backup/restore endpoints)
+  -> PR #2 (aleph-sdk-ts: browser-compatible VmClient rewrite)
+       -> PR #3 (aleph-sdk-ts: version bump + publish)
+            -> PR #4 (front-aleph-cloud-page: migrate to VmClient)
+```
+
+### PR #1: `aleph-im/aleph-vm` #874 (exists, by Alie)
+
+Adds `/backup`, `/restore`, `/backup/{id}` endpoints and `DELETE` to allowed auth methods.
+
+### PR #2: `aleph-im/aleph-sdk-ts` (rewrite of #202)
+
+Browser-compatible VmClient with Web Crypto API, log streaming, resource reservation.
+
+### PR #3: `aleph-im/aleph-sdk-ts`
+
+Version bump and npm publish of `@aleph-sdk/client`.
+
+### PR #4: `aleph-im/front-aleph-cloud-page`
+
+Replace `ExecutableManager` VM control code with `@aleph-sdk/client` VmClient. Remove ~200 lines of duplicated auth/crypto code.
+
+### Optional follow-ups
+
+- Integration tests against a live CRN
+- Clean up any remaining duplicated CRN auth code in front-end

--- a/docs/plans/2026-02-26-vmclient-implementation.md
+++ b/docs/plans/2026-02-26-vmclient-implementation.md
@@ -1,0 +1,1403 @@
+# VmClient Browser-Compatible Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Rewrite VmClient to use Web Crypto API (browser + Node.js), add log streaming and resource reservation, then migrate the front-end to consume it.
+
+**Architecture:** VmClient lives in `@aleph-sdk/client`. It uses `crypto.subtle` for ephemeral P-256 key generation and ES256 operation signing. Wallet signatures are delegated to the existing `Account.sign()` abstraction. A static factory `VmClient.create()` handles async key generation. WebSocket log streaming follows the existing SDK pattern (browser native WebSocket vs `ws` for Node.js).
+
+**Tech Stack:** TypeScript, Web Crypto API (`crypto.subtle`), WebSocket, Jest
+
+---
+
+## PR #2: Browser-Compatible VmClient (aleph-sdk-ts) -- COMPLETED
+
+Implemented as PR #203. PR #1 (aleph-vm #874) already exists. PR #3 and #4 come after.
+
+**Status:** All 8 tasks completed. PR #203 created, PR #202 closed (superseded).
+
+---
+
+### Task 1: Hex encoding utilities
+
+**Files:**
+- Create: `packages/client/src/utils/hex.ts`
+- Test: `packages/client/__tests__/hex.test.ts`
+
+These replace `Buffer.from(...).toString('hex')` and `Buffer.from(str, 'hex')` with browser-safe equivalents. The SDK already uses `Buffer` via polyfills in browser contexts, but these utilities keep VmClient dependency-free.
+
+**Step 1: Write the failing tests**
+
+Create `packages/client/__tests__/hex.test.ts`:
+
+```typescript
+import { bytesToHex, hexToBytes, utf8ToBytes, bytesToUtf8 } from '../src/utils/hex'
+
+describe('hex utilities', () => {
+  it('should round-trip bytes through hex', () => {
+    const original = new Uint8Array([0, 1, 127, 128, 255])
+    const hex = bytesToHex(original)
+    expect(hex).toBe('00017f80ff')
+    expect(hexToBytes(hex)).toEqual(original)
+  })
+
+  it('should handle empty input', () => {
+    expect(bytesToHex(new Uint8Array(0))).toBe('')
+    expect(hexToBytes('')).toEqual(new Uint8Array(0))
+  })
+
+  it('should encode UTF-8 strings to bytes and back', () => {
+    const str = '{"hello":"world"}'
+    const bytes = utf8ToBytes(str)
+    expect(bytesToUtf8(bytes)).toBe(str)
+  })
+
+  it('should handle UTF-8 with non-ASCII characters', () => {
+    const str = 'expires: 2026-02-26T00:00:00.000Z'
+    expect(bytesToUtf8(utf8ToBytes(str))).toBe(str)
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx jest packages/client/__tests__/hex.test.ts --verbose`
+Expected: FAIL — module not found
+
+**Step 3: Write the implementation**
+
+Create `packages/client/src/utils/hex.ts`:
+
+```typescript
+export function bytesToHex(bytes: Uint8Array): string {
+  let hex = ''
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, '0')
+  }
+  return hex
+}
+
+export function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16)
+  }
+  return bytes
+}
+
+export function utf8ToBytes(str: string): Uint8Array {
+  return new TextEncoder().encode(str)
+}
+
+export function bytesToUtf8(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes)
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx jest packages/client/__tests__/hex.test.ts --verbose`
+Expected: PASS (4 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/client/src/utils/hex.ts packages/client/__tests__/hex.test.ts
+git commit -m "feat(client): add browser-safe hex encoding utilities"
+```
+
+---
+
+### Task 2: VmClient types and VmOperation enum
+
+**Files:**
+- Create: `packages/client/src/vmClient.ts`
+
+No tests yet — just the type foundation that other tests will import.
+
+**Step 1: Write the types**
+
+Create `packages/client/src/vmClient.ts`:
+
+```typescript
+import { Account } from '@aleph-sdk/account'
+import { Blockchain } from '@aleph-sdk/core'
+
+import { bytesToHex, utf8ToBytes } from './utils/hex'
+
+// --- Types ---
+
+export enum VmOperation {
+  Stop = 'stop',
+  Reboot = 'reboot',
+  Erase = 'erase',
+  Expire = 'expire',
+  Reinstall = 'reinstall',
+  Backup = 'backup',
+  Restore = 'restore',
+  StreamLogs = 'stream_logs',
+  Update = 'update',
+}
+
+export type VmOperationResult = {
+  status: number | null
+  response: string
+}
+
+export type LogEntry = {
+  type: 'stdout' | 'stderr'
+  message: string
+}
+
+// --- Base58 decoder (for Solana signature conversion) ---
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+function base58Decode(input: string): Uint8Array {
+  if (input.length === 0) return new Uint8Array(0)
+
+  const bytes = [0]
+  for (const char of input) {
+    const value = BASE58_ALPHABET.indexOf(char)
+    if (value < 0) throw new Error(`Invalid base58 character: ${char}`)
+
+    let carry = value
+    for (let j = 0; j < bytes.length; j++) {
+      carry += bytes[j] * 58
+      bytes[j] = carry & 0xff
+      carry >>= 8
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff)
+      carry >>= 8
+    }
+  }
+
+  let leadingZeros = 0
+  for (const char of input) {
+    if (char !== '1') break
+    leadingZeros++
+  }
+
+  const result = new Uint8Array(leadingZeros + bytes.length)
+  const reversed = bytes.reverse()
+  result.set(new Uint8Array(reversed), leadingZeros)
+  return result
+}
+```
+
+This is just the foundation — the class comes in the next task.
+
+**Step 2: Commit**
+
+```bash
+git add packages/client/src/vmClient.ts
+git commit -m "feat(client): add VmClient types and VmOperation enum"
+```
+
+---
+
+### Task 3: VmClient core — static factory, ephemeral key, pubkey header
+
+This is the heart of the implementation: async key generation and wallet-signed pubkey header.
+
+**Files:**
+- Modify: `packages/client/src/vmClient.ts`
+- Test: `packages/client/__tests__/vmClient.test.ts`
+
+**Step 1: Write failing tests for construction and auth headers**
+
+Create `packages/client/__tests__/vmClient.test.ts`:
+
+```typescript
+import { Blockchain } from '../../core/src'
+import { VmClient, VmOperation } from '../src/vmClient'
+
+// --- Mock Account ---
+
+function createMockAccount(chain: Blockchain = Blockchain.ETH) {
+  return {
+    address: '0xTestAddress1234567890',
+    getChain: () => chain,
+    sign: jest.fn().mockResolvedValue('0xmocksignature123'),
+  }
+}
+
+// --- Mock fetch ---
+
+const mockFetch = jest.fn()
+global.fetch = mockFetch as unknown as typeof fetch
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  mockFetch.mockResolvedValue({
+    status: 200,
+    text: () => Promise.resolve('OK'),
+  })
+})
+
+// --- Tests ---
+
+describe('VmClient', () => {
+  describe('create (static factory)', () => {
+    it('should create a VmClient asynchronously', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+      expect(client.nodeDomain).toBe('crn.example.com')
+    })
+
+    it('should strip trailing slashes from node URL', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com///')
+      expect(client.nodeDomain).toBe('crn.example.com')
+    })
+
+    it('should throw if node URL has no hostname', async () => {
+      const account = createMockAccount()
+      await expect(VmClient.create(account, 'not-a-url')).rejects.toThrow()
+    })
+  })
+
+  describe('authentication headers', () => {
+    it('should produce valid X-SignedPubKey header', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.stopInstance('vm123')
+
+      const [, options] = mockFetch.mock.calls[0]
+      const pubkeyHeader = JSON.parse(options.headers['X-SignedPubKey'])
+
+      expect(pubkeyHeader.sender).toBe('0xTestAddress1234567890')
+      expect(pubkeyHeader.payload).toBeDefined()
+      expect(pubkeyHeader.signature).toBe('0xmocksignature123')
+      expect(pubkeyHeader.content.domain).toBe('crn.example.com')
+
+      const payloadJson = JSON.parse(
+        new TextDecoder().decode(
+          Uint8Array.from(
+            (pubkeyHeader.payload.match(/.{2}/g) || []).map((b: string) => parseInt(b, 16)),
+          ),
+        ),
+      )
+      expect(payloadJson.pubkey).toBeDefined()
+      expect(payloadJson.alg).toBe('ECDSA')
+      expect(payloadJson.domain).toBe('crn.example.com')
+      expect(payloadJson.address).toBe('0xTestAddress1234567890')
+      expect(payloadJson.chain).toBe('ETH')
+      expect(payloadJson.expires).toBeDefined()
+    })
+
+    it('should produce valid X-SignedOperation header', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.stopInstance('vm123')
+
+      const [, options] = mockFetch.mock.calls[0]
+      const opHeader = JSON.parse(options.headers['X-SignedOperation'])
+
+      expect(opHeader.payload).toBeDefined()
+      expect(opHeader.signature).toBeDefined()
+
+      const payloadJson = JSON.parse(
+        new TextDecoder().decode(
+          Uint8Array.from(
+            (opHeader.payload.match(/.{2}/g) || []).map((b: string) => parseInt(b, 16)),
+          ),
+        ),
+      )
+      expect(payloadJson.time).toBeDefined()
+      expect(payloadJson.method).toBe('POST')
+      expect(payloadJson.path).toBe('/control/machine/vm123/stop')
+      expect(payloadJson.domain).toBe('crn.example.com')
+    })
+
+    it('should reuse pubkey header across requests', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.stopInstance('vm1')
+      await client.rebootInstance('vm2')
+
+      // account.sign should only be called once (for pubkey header)
+      expect(account.sign).toHaveBeenCalledTimes(1)
+
+      const header1 = mockFetch.mock.calls[0][1].headers['X-SignedPubKey']
+      const header2 = mockFetch.mock.calls[1][1].headers['X-SignedPubKey']
+      expect(header1).toBe(header2)
+    })
+
+    it('should set chain to SOL for Solana accounts', async () => {
+      const account = createMockAccount(Blockchain.SOL)
+      account.sign.mockResolvedValue(
+        JSON.stringify({
+          signature: '11111111111111111111111111111111',
+          publicKey: 'SolPubKey123',
+        }),
+      )
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.stopInstance('vm123')
+
+      const [, options] = mockFetch.mock.calls[0]
+      const pubkeyHeader = JSON.parse(options.headers['X-SignedPubKey'])
+      const payloadJson = JSON.parse(
+        new TextDecoder().decode(
+          Uint8Array.from(
+            (pubkeyHeader.payload.match(/.{2}/g) || []).map((b: string) => parseInt(b, 16)),
+          ),
+        ),
+      )
+      expect(payloadJson.chain).toBe('SOL')
+    })
+  })
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npx jest packages/client/__tests__/vmClient.test.ts --verbose`
+Expected: FAIL — `VmClient.create` is not a function
+
+**Step 3: Implement VmClient core**
+
+Append to `packages/client/src/vmClient.ts` (after the existing types):
+
+```typescript
+// --- VmClient ---
+
+/**
+ * Client for managing VM instances on Aleph CRN (Compute Resource Node)
+ * endpoints. Provides authenticated access to instance lifecycle operations
+ * including start, stop, reboot, erase, reinstall, backup, and restore.
+ *
+ * Uses Web Crypto API for browser + Node.js compatibility.
+ *
+ * Authentication uses a two-header scheme:
+ * - X-SignedPubKey: ephemeral P-256 public key signed by wallet (24h validity)
+ * - X-SignedOperation: per-request payload signed by ephemeral key (ES256)
+ */
+export class VmClient {
+  private readonly account: Account
+  private readonly nodeUrl: string
+  private readonly ephemeralPublicKey: CryptoKey
+  private readonly ephemeralPrivateKey: CryptoKey
+  private readonly pubkeyPayload: Record<string, unknown>
+  private pubkeySignatureHeader: string | null = null
+
+  private constructor(
+    account: Account,
+    nodeUrl: string,
+    publicKey: CryptoKey,
+    privateKey: CryptoKey,
+  ) {
+    this.account = account
+    this.nodeUrl = nodeUrl.replace(/\/+$/, '')
+    this.ephemeralPublicKey = publicKey
+    this.ephemeralPrivateKey = privateKey
+    this.pubkeyPayload = this.buildPubkeyPayload()
+  }
+
+  static async create(account: Account, nodeUrl: string): Promise<VmClient> {
+    // Validate URL early
+    const url = new URL(nodeUrl.replace(/\/+$/, ''))
+    if (!url.hostname) {
+      throw new Error('Could not parse node domain from URL')
+    }
+
+    const keyPair = await crypto.subtle.generateKey(
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      true,
+      ['sign', 'verify'],
+    )
+
+    return new VmClient(account, nodeUrl, keyPair.publicKey, keyPair.privateKey)
+  }
+
+  get nodeDomain(): string {
+    return new URL(this.nodeUrl).hostname
+  }
+
+  // --- Authentication internals ---
+
+  private buildPubkeyPayload(): Record<string, unknown> {
+    // Export public key synchronously is not possible with CryptoKey.
+    // We do it lazily in ensurePubkeyHeader instead.
+    // This method builds the non-key parts of the payload.
+    const expires = new Date(Date.now() + 24 * 60 * 60 * 1000)
+
+    return {
+      alg: 'ECDSA',
+      domain: this.nodeDomain,
+      address: this.account.address,
+      expires: expires.toISOString(),
+      chain: this.account.getChain() === Blockchain.SOL ? 'SOL' : 'ETH',
+    }
+  }
+
+  private async ensurePubkeyHeader(): Promise<string> {
+    if (!this.pubkeySignatureHeader) {
+      this.pubkeySignatureHeader = await this.buildPubkeySignatureHeader()
+    }
+    return this.pubkeySignatureHeader
+  }
+
+  private async buildPubkeySignatureHeader(): Promise<string> {
+    const jwk = await crypto.subtle.exportKey('jwk', this.ephemeralPublicKey)
+    const fullPayload = { pubkey: jwk, ...this.pubkeyPayload }
+    const jsonString = JSON.stringify(fullPayload)
+    const jsonBytes = utf8ToBytes(jsonString)
+    const hexPayload = bytesToHex(jsonBytes)
+    const isSOL = this.account.getChain() === Blockchain.SOL
+
+    const signable = {
+      time: 0,
+      sender: this.account.address,
+      getVerificationBuffer: () =>
+        Buffer.from(isSOL ? utf8ToBytes(hexPayload) : jsonBytes),
+    }
+
+    const rawSignature = await this.account.sign(signable)
+    const signature = isSOL
+      ? this.convertSolSignatureToHex(rawSignature)
+      : rawSignature
+
+    return JSON.stringify({
+      sender: this.account.address,
+      payload: hexPayload,
+      signature,
+      content: { domain: this.nodeDomain },
+    })
+  }
+
+  private convertSolSignatureToHex(jsonSignature: string): string {
+    const parsed = JSON.parse(jsonSignature) as {
+      signature: string
+      publicKey: string
+    }
+    const bytes = base58Decode(parsed.signature)
+    return '0x' + bytesToHex(bytes)
+  }
+
+  private async signControlPayload(
+    payload: Record<string, string>,
+  ): Promise<string> {
+    const payloadBytes = utf8ToBytes(JSON.stringify(payload))
+    const signature = await crypto.subtle.sign(
+      { name: 'ECDSA', hash: { name: 'SHA-256' } },
+      this.ephemeralPrivateKey,
+      payloadBytes,
+    )
+
+    return JSON.stringify({
+      payload: bytesToHex(payloadBytes),
+      signature: bytesToHex(new Uint8Array(signature)),
+    })
+  }
+
+  private buildControlPayload(
+    vmId: string,
+    operation: string,
+    method: string,
+  ): Record<string, string> {
+    return {
+      time: new Date().toISOString(),
+      method: method.toUpperCase(),
+      path: `/control/machine/${vmId}/${operation}`,
+      domain: this.nodeDomain,
+    }
+  }
+
+  async buildHeaders(
+    vmId: string,
+    operation: string,
+    method: string,
+  ): Promise<{ url: string; headers: Record<string, string> }> {
+    const payload = this.buildControlPayload(vmId, operation, method)
+    const signedOperation = await this.signControlPayload(payload)
+    const pubkeyHeader = await this.ensurePubkeyHeader()
+
+    return {
+      url: `${this.nodeUrl}${payload.path}`,
+      headers: {
+        'X-SignedPubKey': pubkeyHeader,
+        'X-SignedOperation': signedOperation,
+      },
+    }
+  }
+
+  // --- Generic operation ---
+
+  async performOperation(
+    vmId: string,
+    operation: string,
+    options?: {
+      method?: string
+      params?: Record<string, string>
+      jsonData?: Record<string, unknown>
+    },
+  ): Promise<VmOperationResult> {
+    const method = options?.method ?? 'POST'
+    const { url, headers } = await this.buildHeaders(vmId, operation, method)
+
+    const requestUrl = new URL(url)
+    if (options?.params) {
+      for (const [key, value] of Object.entries(options.params)) {
+        requestUrl.searchParams.set(key, value)
+      }
+    }
+
+    const fetchHeaders: Record<string, string> = { ...headers }
+    const fetchOptions: RequestInit = {
+      method,
+      headers: fetchHeaders,
+    }
+    if (options?.jsonData) {
+      fetchOptions.body = JSON.stringify(options.jsonData)
+      fetchHeaders['Content-Type'] = 'application/json'
+    }
+
+    try {
+      const response = await fetch(requestUrl.toString(), fetchOptions)
+      return {
+        status: response.status,
+        response: await response.text(),
+      }
+    } catch (error) {
+      return { status: null, response: String(error) }
+    }
+  }
+
+  // --- Instance lifecycle ---
+
+  async startInstance(vmId: string): Promise<VmOperationResult> {
+    try {
+      const response = await fetch(
+        `${this.nodeUrl}/control/allocation/notify`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ instance: vmId }),
+        },
+      )
+      return {
+        status: response.status,
+        response: await response.text(),
+      }
+    } catch (error) {
+      return { status: null, response: String(error) }
+    }
+  }
+
+  async stopInstance(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Stop)
+  }
+
+  async rebootInstance(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Reboot)
+  }
+
+  async eraseInstance(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Erase)
+  }
+
+  async expireInstance(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Expire)
+  }
+
+  // --- Reinstall ---
+
+  async reinstallInstance(
+    vmId: string,
+    eraseVolumes = true,
+  ): Promise<VmOperationResult> {
+    const params = eraseVolumes ? undefined : { erase_volumes: 'false' }
+    return this.performOperation(vmId, VmOperation.Reinstall, { params })
+  }
+
+  // --- Backup ---
+
+  async createBackup(
+    vmId: string,
+    options?: {
+      includeVolumes?: boolean
+      skipFsfreeze?: boolean
+    },
+  ): Promise<VmOperationResult> {
+    const params: Record<string, string> = {}
+    if (options?.includeVolumes) params['include_volumes'] = 'true'
+    if (options?.skipFsfreeze) params['skip_fsfreeze'] = 'true'
+
+    return this.performOperation(vmId, VmOperation.Backup, {
+      params: Object.keys(params).length > 0 ? params : undefined,
+    })
+  }
+
+  async getBackup(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Backup, { method: 'GET' })
+  }
+
+  async deleteBackup(
+    vmId: string,
+    backupId: string,
+  ): Promise<VmOperationResult> {
+    if (!/^[a-zA-Z0-9_-]+$/.test(backupId)) {
+      throw new Error(`Invalid backup ID format: ${backupId}`)
+    }
+    return this.performOperation(vmId, `backup/${backupId}`, {
+      method: 'DELETE',
+    })
+  }
+
+  // --- Restore ---
+
+  async restoreFromVolume(
+    vmId: string,
+    volumeRef: string,
+  ): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Restore, {
+      jsonData: { volume_ref: volumeRef },
+    })
+  }
+
+  async restoreFromFile(
+    vmId: string,
+    rootfsData: Blob,
+  ): Promise<VmOperationResult> {
+    const { url, headers } = await this.buildHeaders(
+      vmId,
+      VmOperation.Restore,
+      'POST',
+    )
+
+    const formData = new FormData()
+    formData.append('rootfs', rootfsData)
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: formData,
+      })
+      return {
+        status: response.status,
+        response: await response.text(),
+      }
+    } catch (error) {
+      return { status: null, response: String(error) }
+    }
+  }
+
+  async getRestoreEndpoint(
+    vmId: string,
+  ): Promise<{ url: string; headers: Record<string, string> }> {
+    return this.buildHeaders(vmId, VmOperation.Restore, 'POST')
+  }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npx jest packages/client/__tests__/vmClient.test.ts --verbose`
+Expected: PASS (all 7 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/client/src/vmClient.ts packages/client/__tests__/vmClient.test.ts
+git commit -m "feat(client): VmClient core with Web Crypto API"
+```
+
+---
+
+### Task 4: VmClient lifecycle and operation tests
+
+**Files:**
+- Modify: `packages/client/__tests__/vmClient.test.ts`
+
+Add tests for all lifecycle operations, backup, restore, reinstall, query params, JSON body, error handling.
+
+**Step 1: Append tests to `vmClient.test.ts`**
+
+Add inside the outer `describe('VmClient', ...)` block:
+
+```typescript
+  describe('performOperation', () => {
+    it('should send authenticated POST request', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      const result = await client.performOperation('vm123', VmOperation.Stop)
+
+      expect(result.status).toBe(200)
+      expect(result.response).toBe('OK')
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/stop')
+      expect(options.method).toBe('POST')
+      expect(options.headers['X-SignedPubKey']).toBeDefined()
+      expect(options.headers['X-SignedOperation']).toBeDefined()
+    })
+
+    it('should include query params when provided', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.performOperation('vm123', VmOperation.Reinstall, {
+        params: { erase_volumes: 'false' },
+      })
+
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).toContain('erase_volumes=false')
+    })
+
+    it('should send JSON body when provided', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.performOperation('vm123', VmOperation.Restore, {
+        jsonData: { volume_ref: 'abc123' },
+      })
+
+      const [, options] = mockFetch.mock.calls[0]
+      expect(options.body).toBe('{"volume_ref":"abc123"}')
+      expect(options.headers['Content-Type']).toBe('application/json')
+    })
+
+    it('should use GET method when specified', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.performOperation('vm123', VmOperation.Backup, {
+        method: 'GET',
+      })
+
+      const [, options] = mockFetch.mock.calls[0]
+      expect(options.method).toBe('GET')
+    })
+
+    it('should return null status on network error', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network failure'))
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      const result = await client.performOperation('vm123', VmOperation.Stop)
+
+      expect(result.status).toBeNull()
+      expect(result.response).toContain('Network failure')
+    })
+  })
+
+  describe('instance lifecycle', () => {
+    it('stopInstance should POST to stop', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.stopInstance('vm123')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/stop')
+      expect(options.method).toBe('POST')
+    })
+
+    it('rebootInstance should POST to reboot', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.rebootInstance('vm123')
+
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/reboot')
+    })
+
+    it('eraseInstance should POST to erase', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.eraseInstance('vm123')
+
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/erase')
+    })
+
+    it('expireInstance should POST to expire', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.expireInstance('vm123')
+
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/expire')
+    })
+
+    it('startInstance should POST to allocation notify', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.startInstance('vm123')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toBe('https://crn.example.com/control/allocation/notify')
+      expect(options.method).toBe('POST')
+      expect(JSON.parse(options.body)).toEqual({ instance: 'vm123' })
+    })
+  })
+
+  describe('reinstallInstance', () => {
+    it('should POST to reinstall without params by default', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.reinstallInstance('vm123')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/reinstall')
+      expect(url).not.toContain('erase_volumes')
+      expect(options.method).toBe('POST')
+    })
+
+    it('should add erase_volumes=false when eraseVolumes is false', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.reinstallInstance('vm123', false)
+
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).toContain('erase_volumes=false')
+    })
+  })
+
+  describe('backup operations', () => {
+    it('createBackup should POST to backup', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.createBackup('vm123')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/backup')
+      expect(options.method).toBe('POST')
+    })
+
+    it('createBackup should include options as query params', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.createBackup('vm123', {
+        includeVolumes: true,
+        skipFsfreeze: true,
+      })
+
+      const [url] = mockFetch.mock.calls[0]
+      expect(url).toContain('include_volumes=true')
+      expect(url).toContain('skip_fsfreeze=true')
+    })
+
+    it('getBackup should GET backup info', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.getBackup('vm123')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/backup')
+      expect(options.method).toBe('GET')
+    })
+
+    it('deleteBackup should DELETE specific backup', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.deleteBackup('vm123', 'backup-abc_123')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/backup/backup-abc_123')
+      expect(options.method).toBe('DELETE')
+    })
+
+    it('deleteBackup should reject invalid backup IDs', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await expect(
+        client.deleteBackup('vm123', '../etc/passwd'),
+      ).rejects.toThrow('Invalid backup ID format')
+    })
+  })
+
+  describe('restore operations', () => {
+    it('restoreFromVolume should POST with volume_ref JSON body', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      await client.restoreFromVolume('vm123', 'volume-hash-abc')
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/restore')
+      expect(options.method).toBe('POST')
+      expect(JSON.parse(options.body)).toEqual({
+        volume_ref: 'volume-hash-abc',
+      })
+    })
+
+    it('restoreFromFile should POST multipart form data', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      const fakeData = new Blob(['fake rootfs data'])
+      await client.restoreFromFile('vm123', fakeData)
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/machine/vm123/restore')
+      expect(options.method).toBe('POST')
+      expect(options.body).toBeInstanceOf(FormData)
+    })
+
+    it('getRestoreEndpoint should return URL and headers', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      const endpoint = await client.getRestoreEndpoint('vm123')
+
+      expect(endpoint.url).toContain('/control/machine/vm123/restore')
+      expect(endpoint.headers['X-SignedPubKey']).toBeDefined()
+      expect(endpoint.headers['X-SignedOperation']).toBeDefined()
+    })
+  })
+```
+
+**Step 2: Run tests**
+
+Run: `npx jest packages/client/__tests__/vmClient.test.ts --verbose`
+Expected: PASS (all tests — implementation already covers these)
+
+**Step 3: Commit**
+
+```bash
+git add packages/client/__tests__/vmClient.test.ts
+git commit -m "test(client): comprehensive VmClient operation tests"
+```
+
+---
+
+### Task 5: Log streaming
+
+**Files:**
+- Modify: `packages/client/src/vmClient.ts`
+- Modify: `packages/client/__tests__/vmClient.test.ts`
+
+Log streaming uses WebSocket with auth sent as the first message. The SDK already has a browser/Node WebSocket pattern, but for VmClient we use native WebSocket (available in Node 22+ and all browsers). Since the SDK targets Node 20+, we use `isNode()` from `@aleph-sdk/core` to conditionally import `ws` for Node < 22.
+
+However, since the monorepo targets Node 20+, and Node 21+ has native WebSocket behind a flag, and Node 22+ has it stable, and the front-end is the primary consumer (browser), we can use native WebSocket and document Node 22+ as required for log streaming in Node.js.
+
+**Step 1: Write failing test**
+
+Append to `vmClient.test.ts`:
+
+```typescript
+  describe('streamLogs', () => {
+    it('should build correct WebSocket URL and auth message', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      // We can't easily mock WebSocket in Jest, so test the
+      // buildHeaders output that streamLogs would use
+      const { url, headers } = await client.buildHeaders(
+        'vm123',
+        VmOperation.StreamLogs,
+        'GET',
+      )
+
+      expect(url).toBe(
+        'https://crn.example.com/control/machine/vm123/stream_logs',
+      )
+      expect(headers['X-SignedPubKey']).toBeDefined()
+      expect(headers['X-SignedOperation']).toBeDefined()
+    })
+  })
+```
+
+**Step 2: Add streamLogs to VmClient**
+
+Add to the VmClient class in `vmClient.ts`:
+
+```typescript
+  // --- Log streaming ---
+
+  async *streamLogs(
+    vmId: string,
+    abort?: AbortSignal,
+  ): AsyncGenerator<LogEntry> {
+    const { headers } = await this.buildHeaders(
+      vmId,
+      VmOperation.StreamLogs,
+      'GET',
+    )
+
+    const wsUrl = this.nodeUrl.replace(/^http/, 'ws') +
+      `/control/machine/${vmId}/stream_logs`
+
+    const ws = new WebSocket(wsUrl)
+
+    const messageQueue: LogEntry[] = []
+    let resolve: (() => void) | null = null
+    let closed = false
+    let error: Error | null = null
+
+    ws.onopen = () => {
+      ws.send(
+        JSON.stringify({
+          auth: {
+            'X-SignedPubKey': JSON.parse(headers['X-SignedPubKey']),
+            'X-SignedOperation': JSON.parse(headers['X-SignedOperation']),
+          },
+        }),
+      )
+    }
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(
+          typeof event.data === 'string'
+            ? event.data
+            : event.data.toString(),
+        )
+        if (data.type && data.message !== undefined) {
+          messageQueue.push({
+            type: data.type,
+            message: data.message,
+          })
+          resolve?.()
+        }
+      } catch {
+        // Skip non-JSON messages
+      }
+    }
+
+    ws.onerror = (event) => {
+      error = new Error('WebSocket error')
+      resolve?.()
+    }
+
+    ws.onclose = () => {
+      closed = true
+      resolve?.()
+    }
+
+    abort?.addEventListener('abort', () => {
+      ws.close(1000, 'aborted')
+    })
+
+    try {
+      while (!closed) {
+        if (messageQueue.length > 0) {
+          yield messageQueue.shift()!
+          continue
+        }
+        if (error) throw error
+        await new Promise<void>((r) => { resolve = r })
+        resolve = null
+      }
+      // Drain remaining messages
+      while (messageQueue.length > 0) {
+        yield messageQueue.shift()!
+      }
+    } finally {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.close(1000)
+      }
+    }
+  }
+```
+
+**Step 3: Run tests**
+
+Run: `npx jest packages/client/__tests__/vmClient.test.ts --verbose`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add packages/client/src/vmClient.ts packages/client/__tests__/vmClient.test.ts
+git commit -m "feat(client): add WebSocket log streaming to VmClient"
+```
+
+---
+
+### Task 6: Resource reservation
+
+**Files:**
+- Modify: `packages/client/src/vmClient.ts`
+- Modify: `packages/client/__tests__/vmClient.test.ts`
+
+This matches the front-end's `reserveCRNResources` — POST to `/control/reserve_resources` with auth headers and instance config as body.
+
+**Step 1: Write failing test**
+
+Append to `vmClient.test.ts`:
+
+```typescript
+  describe('reserveResources', () => {
+    it('should POST to /control/reserve_resources with auth headers', async () => {
+      const account = createMockAccount()
+      const client = await VmClient.create(account, 'https://crn.example.com')
+
+      const config = { instance: 'vm123', resources: { vcpus: 2 } }
+      await client.reserveResources(config)
+
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/control/reserve_resources')
+      expect(options.method).toBe('POST')
+      expect(JSON.parse(options.body)).toEqual(config)
+      expect(options.headers['X-SignedPubKey']).toBeDefined()
+      expect(options.headers['X-SignedOperation']).toBeDefined()
+    })
+  })
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx jest packages/client/__tests__/vmClient.test.ts -t "reserveResources" --verbose`
+Expected: FAIL — `reserveResources` is not a function
+
+**Step 3: Add reserveResources to VmClient**
+
+Add to the VmClient class:
+
+```typescript
+  // --- Resource reservation ---
+
+  async reserveResources(
+    config: Record<string, unknown>,
+  ): Promise<VmOperationResult> {
+    const path = '/control/reserve_resources'
+    const payload = {
+      time: new Date().toISOString(),
+      method: 'POST',
+      path,
+      domain: this.nodeDomain,
+    }
+    const signedOperation = await this.signControlPayload(payload)
+    const pubkeyHeader = await this.ensurePubkeyHeader()
+
+    try {
+      const response = await fetch(`${this.nodeUrl}${path}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-SignedPubKey': pubkeyHeader,
+          'X-SignedOperation': signedOperation,
+        },
+        body: JSON.stringify(config),
+      })
+      return {
+        status: response.status,
+        response: await response.text(),
+      }
+    } catch (error) {
+      return { status: null, response: String(error) }
+    }
+  }
+```
+
+**Step 4: Run test**
+
+Run: `npx jest packages/client/__tests__/vmClient.test.ts -t "reserveResources" --verbose`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/client/src/vmClient.ts packages/client/__tests__/vmClient.test.ts
+git commit -m "feat(client): add CRN resource reservation to VmClient"
+```
+
+---
+
+### Task 7: Export and build
+
+**Files:**
+- Modify: `packages/client/src/index.ts`
+
+**Step 1: Add VmClient export**
+
+Update `packages/client/src/index.ts`:
+
+```typescript
+export * from './httpClient'
+export * from './authenticatedHttpClient'
+export * from './vmClient'
+```
+
+**Step 2: Build the full monorepo**
+
+Run: `npm run build`
+Expected: All 16 packages build successfully
+
+**Step 3: Run all client tests**
+
+Run: `npx jest packages/client/ --verbose`
+Expected: All tests pass
+
+**Step 4: Commit**
+
+```bash
+git add packages/client/src/index.ts
+git commit -m "feat(client): export VmClient from @aleph-sdk/client"
+```
+
+---
+
+### Task 8: Run full test suite and lint
+
+**Step 1: Run full test suite**
+
+Run: `npm test`
+Expected: All tests pass across all packages
+
+**Step 2: Run linter**
+
+Run: `npm run lint`
+Expected: No errors
+
+**Step 3: Fix any issues found, commit if needed**
+
+---
+
+## PR #4: Front-End Migration (front-aleph-cloud-page)
+
+This PR is separate and depends on PR #2 being merged and published.
+
+### Task 9: Update SDK dependency
+
+**Files:**
+- Modify: `package.json`
+
+**Step 1: Update @aleph-sdk/client to new version**
+
+```bash
+npm install @aleph-sdk/client@latest
+```
+
+**Step 2: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: update @aleph-sdk/client with VmClient"
+```
+
+---
+
+### Task 10: Replace ExecutableManager auth + operations
+
+**Files:**
+- Modify: `src/domain/executable.ts`
+
+**Step 1: Remove auth types and methods**
+
+Delete from `executable.ts`:
+- `KeyPair` type
+- `SignedPublicKeyHeader` type
+- `AuthPubKeyToken` type
+- `KEYPAIR_TTL` constant
+- `static cachedPubKeyToken` field
+- `getKeyPair()` method
+- `getAuthPubKeyToken()` method
+- `getAuthOperationToken()` method
+- `sendPostOperation()` method
+- `subscribeLogs()` method
+
+**Step 2: Add VmClient import and usage**
+
+```typescript
+import { VmClient } from '@aleph-sdk/client'
+```
+
+Replace `sendPostOperation` call sites with VmClient methods. The VmClient should be created per CRN node and cached. Add a helper:
+
+```typescript
+private vmClients = new Map<string, VmClient>()
+
+private async getVmClient(nodeUrl: string): Promise<VmClient> {
+  const domain = new URL(nodeUrl).hostname
+  let client = this.vmClients.get(domain)
+  if (!client) {
+    client = await VmClient.create(this.account!, nodeUrl)
+    this.vmClients.set(domain, client)
+  }
+  return client
+}
+```
+
+**Step 3: Replace operation calls**
+
+Find all `this.sendPostOperation(...)` calls and replace with:
+
+```typescript
+const vmClient = await this.getVmClient(hostname)
+await vmClient.stopInstance(vmId)  // or rebootInstance, etc.
+```
+
+**Step 4: Replace log streaming**
+
+Find `this.subscribeLogs(...)` calls and replace with:
+
+```typescript
+const vmClient = await this.getVmClient(hostname)
+const abortController = new AbortController()
+for await (const entry of vmClient.streamLogs(vmId, abortController.signal)) {
+  // handle entry
+}
+```
+
+**Step 5: Replace resource reservation**
+
+Find `this.reserveCRNResources(...)` and replace with:
+
+```typescript
+const vmClient = await this.getVmClient(node.address)
+await vmClient.reserveResources(instanceConfig)
+```
+
+**Step 6: Verify the front-end builds**
+
+```bash
+npm run build
+```
+
+**Step 7: Commit**
+
+```bash
+git add src/domain/executable.ts
+git commit -m "refactor: replace ExecutableManager VM control with VmClient from SDK"
+```
+
+---
+
+### Task 11: Update hooks
+
+**Files:**
+- Modify: `src/hooks/common/useExecutableActions.ts`
+- Modify: `src/hooks/common/useRequestExecutableLogsFeed.ts` (or equivalent)
+
+Update any hook that directly used the removed methods to use the new VmClient-based API from ExecutableManager.
+
+**Step 1: Verify hooks still compile and work**
+
+The hooks call ExecutableManager methods, so if Task 10 preserved the public API (just changed internals), hooks should work unchanged. If any hook directly used `sendPostOperation` or `subscribeLogs`, update those call sites.
+
+**Step 2: Test in browser**
+
+Run dev server and verify:
+- VM stop/start/reboot works
+- Log streaming works
+- No console errors
+
+**Step 3: Commit**
+
+```bash
+git add src/hooks/
+git commit -m "refactor: update hooks for VmClient-based ExecutableManager"
+```

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,5 +23,8 @@ export default {
   cache: true,
   cacheDirectory: '<rootDir>/.jest-cache',
   // Avoid transforming unnecessary files
-  modulePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/examples/'],
+  modulePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/examples/', '<rootDir>/.worktrees/'],
+  moduleNameMapper: {
+    '^@aleph-sdk/(.*)$': '<rootDir>/packages/$1/src',
+  },
 }

--- a/packages/client/__tests__/hex.test.ts
+++ b/packages/client/__tests__/hex.test.ts
@@ -25,6 +25,14 @@ describe('hexToBytes', () => {
   it('should return empty array for empty string', () => {
     expect(hexToBytes('')).toEqual(new Uint8Array([]))
   })
+
+  it('should throw on odd-length hex string', () => {
+    expect(() => hexToBytes('abc')).toThrow('odd length')
+  })
+
+  it('should throw on invalid hex characters', () => {
+    expect(() => hexToBytes('zzzz')).toThrow('Invalid hex character')
+  })
 })
 
 describe('hex round-trip', () => {

--- a/packages/client/__tests__/hex.test.ts
+++ b/packages/client/__tests__/hex.test.ts
@@ -1,0 +1,68 @@
+import { bytesToHex, hexToBytes, utf8ToBytes, bytesToUtf8 } from '../src/utils/hex'
+
+describe('bytesToHex', () => {
+  it('should convert bytes to hex string', () => {
+    const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef])
+    expect(bytesToHex(bytes)).toBe('deadbeef')
+  })
+
+  it('should pad single-digit hex values with leading zero', () => {
+    const bytes = new Uint8Array([0x01, 0x02, 0x0a])
+    expect(bytesToHex(bytes)).toBe('01020a')
+  })
+
+  it('should return empty string for empty input', () => {
+    expect(bytesToHex(new Uint8Array([]))).toBe('')
+  })
+})
+
+describe('hexToBytes', () => {
+  it('should convert hex string to bytes', () => {
+    const bytes = hexToBytes('deadbeef')
+    expect(bytes).toEqual(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))
+  })
+
+  it('should return empty array for empty string', () => {
+    expect(hexToBytes('')).toEqual(new Uint8Array([]))
+  })
+})
+
+describe('hex round-trip', () => {
+  it('should round-trip bytes through hex and back', () => {
+    const original = new Uint8Array([0, 1, 127, 128, 255])
+    expect(hexToBytes(bytesToHex(original))).toEqual(original)
+  })
+
+  it('should round-trip hex through bytes and back', () => {
+    const original = 'ff00ab12'
+    expect(bytesToHex(hexToBytes(original))).toBe(original)
+  })
+})
+
+describe('utf8ToBytes', () => {
+  it('should encode ASCII string', () => {
+    const bytes = utf8ToBytes('hello')
+    expect(bytes).toEqual(new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]))
+  })
+
+  it('should encode multi-byte UTF-8 characters', () => {
+    const bytes = utf8ToBytes('\u00e9')
+    expect(bytes).toEqual(new Uint8Array([0xc3, 0xa9]))
+  })
+
+  it('should return empty array for empty string', () => {
+    expect(utf8ToBytes('')).toEqual(new Uint8Array([]))
+  })
+})
+
+describe('bytesToUtf8', () => {
+  it('should decode ASCII bytes', () => {
+    const bytes = new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f])
+    expect(bytesToUtf8(bytes)).toBe('hello')
+  })
+
+  it('should round-trip with utf8ToBytes', () => {
+    const original = 'Hello, world! \u00e9\u00e8\u00ea'
+    expect(bytesToUtf8(utf8ToBytes(original))).toBe(original)
+  })
+})

--- a/packages/client/__tests__/vmClient.test.ts
+++ b/packages/client/__tests__/vmClient.test.ts
@@ -1,12 +1,10 @@
-import { Blockchain } from '@aleph-sdk/core'
 import { Account } from '@aleph-sdk/account'
+import { Blockchain } from '@aleph-sdk/core'
 
-import { VmClient, VmOperation } from '../src/vmClient'
 import { hexToBytes, bytesToUtf8 } from '../src/utils/hex'
+import { VmClient, VmOperation } from '../src/vmClient'
 
-function createMockAccount(
-  chain: Blockchain = Blockchain.ETH,
-): Account {
+function createMockAccount(chain: Blockchain = Blockchain.ETH): Account {
   return {
     address: '0xTestAddress1234567890',
     getChain: () => chain,
@@ -27,34 +25,24 @@ global.fetch = mockFetch
 describe('VmClient.create', () => {
   it('should create a VmClient with a valid URL', async () => {
     const account = createMockAccount()
-    const client = await VmClient.create(
-      account,
-      TEST_NODE_URL,
-    )
+    const client = await VmClient.create(account, TEST_NODE_URL)
     expect(client).toBeInstanceOf(VmClient)
   })
 
   it('should strip trailing slashes from the node URL', async () => {
     const account = createMockAccount()
-    const client = await VmClient.create(
-      account,
-      'https://crn.example.com///',
-    )
+    const client = await VmClient.create(account, 'https://crn.example.com///')
 
     mockFetch.mockClear()
     await client.startInstance(TEST_VM_ID)
 
     const calledUrl = mockFetch.mock.calls[0][0] as string
-    expect(calledUrl).toBe(
-      'https://crn.example.com/control/allocation/notify',
-    )
+    expect(calledUrl).toBe('https://crn.example.com/control/allocation/notify')
   })
 
   it('should reject an invalid URL', async () => {
     const account = createMockAccount()
-    await expect(
-      VmClient.create(account, 'not-a-url'),
-    ).rejects.toThrow('Invalid node URL')
+    await expect(VmClient.create(account, 'not-a-url')).rejects.toThrow('Invalid node URL')
   })
 })
 
@@ -64,47 +52,26 @@ describe('X-SignedPubKey header', () => {
 
   beforeEach(async () => {
     account = createMockAccount()
-    client = await VmClient.create(
-      account,
-      TEST_NODE_URL,
-    )
+    client = await VmClient.create(account, TEST_NODE_URL)
     mockFetch.mockClear()
   })
 
   it('should contain sender, payload, signature, and content.domain', async () => {
-    const { headers } = await client.buildHeaders(
-      TEST_VM_ID,
-      VmOperation.Stop,
-    )
+    const { headers } = await client.buildHeaders(TEST_VM_ID, VmOperation.Stop)
 
-    const pubkeyHeader = JSON.parse(
-      headers['X-SignedPubKey'],
-    )
+    const pubkeyHeader = JSON.parse(headers['X-SignedPubKey'])
 
-    expect(pubkeyHeader.sender).toBe(
-      '0xTestAddress1234567890',
-    )
-    expect(pubkeyHeader.signature).toBe(
-      '0xmocksignature123',
-    )
-    expect(pubkeyHeader.content.domain).toBe(
-      'crn.example.com',
-    )
+    expect(pubkeyHeader.sender).toBe('0xTestAddress1234567890')
+    expect(pubkeyHeader.signature).toBe('0xmocksignature123')
+    expect(pubkeyHeader.content.domain).toBe('crn.example.com')
     expect(typeof pubkeyHeader.payload).toBe('string')
   })
 
   it('should have a payload that hex-decodes to JSON with correct fields', async () => {
-    const { headers } = await client.buildHeaders(
-      TEST_VM_ID,
-      VmOperation.Stop,
-    )
+    const { headers } = await client.buildHeaders(TEST_VM_ID, VmOperation.Stop)
 
-    const pubkeyHeader = JSON.parse(
-      headers['X-SignedPubKey'],
-    )
-    const payloadJson = bytesToUtf8(
-      hexToBytes(pubkeyHeader.payload),
-    )
+    const pubkeyHeader = JSON.parse(headers['X-SignedPubKey'])
+    const payloadJson = bytesToUtf8(hexToBytes(pubkeyHeader.payload))
     const payload = JSON.parse(payloadJson)
 
     expect(payload.pubkey).toBeDefined()
@@ -112,26 +79,16 @@ describe('X-SignedPubKey header', () => {
     expect(payload.pubkey.crv).toBe('P-256')
     expect(payload.alg).toBe('ECDSA')
     expect(payload.domain).toBe('crn.example.com')
-    expect(payload.address).toBe(
-      '0xTestAddress1234567890',
-    )
+    expect(payload.address).toBe('0xTestAddress1234567890')
     expect(payload.chain).toBe('ETH')
     expect(payload.expires).toBeDefined()
   })
 
   it('should reuse the cached pubkey header across requests', async () => {
-    const { headers: h1 } = await client.buildHeaders(
-      TEST_VM_ID,
-      VmOperation.Stop,
-    )
-    const { headers: h2 } = await client.buildHeaders(
-      TEST_VM_ID,
-      VmOperation.Reboot,
-    )
+    const { headers: h1 } = await client.buildHeaders(TEST_VM_ID, VmOperation.Stop)
+    const { headers: h2 } = await client.buildHeaders(TEST_VM_ID, VmOperation.Reboot)
 
-    expect(h1['X-SignedPubKey']).toBe(
-      h2['X-SignedPubKey'],
-    )
+    expect(h1['X-SignedPubKey']).toBe(h2['X-SignedPubKey'])
     expect(account.sign).toHaveBeenCalledTimes(1)
   })
 })
@@ -141,48 +98,28 @@ describe('X-SignedOperation header', () => {
 
   beforeEach(async () => {
     const account = createMockAccount()
-    client = await VmClient.create(
-      account,
-      TEST_NODE_URL,
-    )
+    client = await VmClient.create(account, TEST_NODE_URL)
     mockFetch.mockClear()
   })
 
   it('should contain a payload that hex-decodes to JSON with time, method, path, domain', async () => {
-    const { headers } = await client.buildHeaders(
-      TEST_VM_ID,
-      VmOperation.Stop,
-      'POST',
-    )
+    const { headers } = await client.buildHeaders(TEST_VM_ID, VmOperation.Stop, 'POST')
 
-    const opHeader = JSON.parse(
-      headers['X-SignedOperation'],
-    )
-    const payloadJson = bytesToUtf8(
-      hexToBytes(opHeader.payload),
-    )
+    const opHeader = JSON.parse(headers['X-SignedOperation'])
+    const payloadJson = bytesToUtf8(hexToBytes(opHeader.payload))
     const payload = JSON.parse(payloadJson)
 
     expect(payload.time).toBeDefined()
     expect(payload.method).toBe('POST')
-    expect(payload.path).toBe(
-      `/control/machine/${TEST_VM_ID}/stop`,
-    )
+    expect(payload.path).toBe(`/control/machine/${TEST_VM_ID}/stop`)
     expect(payload.domain).toBe('crn.example.com')
   })
 
   it('should include sender and signature', async () => {
-    const { headers } = await client.buildHeaders(
-      TEST_VM_ID,
-      VmOperation.Stop,
-    )
+    const { headers } = await client.buildHeaders(TEST_VM_ID, VmOperation.Stop)
 
-    const opHeader = JSON.parse(
-      headers['X-SignedOperation'],
-    )
-    expect(opHeader.sender).toBe(
-      '0xTestAddress1234567890',
-    )
+    const opHeader = JSON.parse(headers['X-SignedOperation'])
+    expect(opHeader.sender).toBe('0xTestAddress1234567890')
     expect(typeof opHeader.signature).toBe('string')
     expect(opHeader.signature.length).toBeGreaterThan(0)
   })
@@ -191,25 +128,13 @@ describe('X-SignedOperation header', () => {
 describe('SOL chain handling', () => {
   it('should pass SOL chain in the pubkey payload', async () => {
     const solAccount = createMockAccount(Blockchain.SOL)
-    ;(solAccount.sign as jest.Mock).mockResolvedValue(
-      JSON.stringify({ signature: '2gPmh' }),
-    )
-    const client = await VmClient.create(
-      solAccount,
-      TEST_NODE_URL,
-    )
+    ;(solAccount.sign as jest.Mock).mockResolvedValue(JSON.stringify({ signature: '2gPmh' }))
+    const client = await VmClient.create(solAccount, TEST_NODE_URL)
 
-    const { headers } = await client.buildHeaders(
-      TEST_VM_ID,
-      VmOperation.Stop,
-    )
+    const { headers } = await client.buildHeaders(TEST_VM_ID, VmOperation.Stop)
 
-    const pubkeyHeader = JSON.parse(
-      headers['X-SignedPubKey'],
-    )
-    const payloadJson = bytesToUtf8(
-      hexToBytes(pubkeyHeader.payload),
-    )
+    const pubkeyHeader = JSON.parse(headers['X-SignedPubKey'])
+    const payloadJson = bytesToUtf8(hexToBytes(pubkeyHeader.payload))
     const payload = JSON.parse(payloadJson)
 
     expect(payload.chain).toBe('SOL')
@@ -224,19 +149,12 @@ describe('SOL chain handling', () => {
       }),
     )
 
-    const client = await VmClient.create(
-      solAccount,
-      TEST_NODE_URL,
-    )
+    const client = await VmClient.create(solAccount, TEST_NODE_URL)
 
-    await client.buildHeaders(
-      TEST_VM_ID,
-      VmOperation.Stop,
-    )
+    await client.buildHeaders(TEST_VM_ID, VmOperation.Stop)
 
     expect(solAccount.sign).toHaveBeenCalledTimes(1)
-    const signable = (solAccount.sign as jest.Mock).mock
-      .calls[0][0]
+    const signable = (solAccount.sign as jest.Mock).mock.calls[0][0]
     const verBuf = signable.getVerificationBuffer()
 
     // For SOL, the verification buffer should be UTF-8
@@ -247,14 +165,7 @@ describe('SOL chain handling', () => {
 
     // And the pubkey header signature should be
     // 0x-prefixed hex (converted from base58)
-    const pubkeyHeader = JSON.parse(
-      (
-        await client.buildHeaders(
-          TEST_VM_ID,
-          VmOperation.Stop,
-        )
-      ).headers['X-SignedPubKey'],
-    )
+    const pubkeyHeader = JSON.parse((await client.buildHeaders(TEST_VM_ID, VmOperation.Stop)).headers['X-SignedPubKey'])
     expect(pubkeyHeader.signature).toMatch(/^0x[0-9a-f]+$/)
   })
 })
@@ -264,10 +175,7 @@ describe('performOperation', () => {
 
   beforeEach(async () => {
     const account = createMockAccount()
-    client = await VmClient.create(
-      account,
-      TEST_NODE_URL,
-    )
+    client = await VmClient.create(account, TEST_NODE_URL)
     mockFetch.mockClear()
     mockFetch.mockResolvedValue({
       status: 200,
@@ -280,14 +188,10 @@ describe('performOperation', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
     const [url, options] = mockFetch.mock.calls[0]
-    expect(url).toBe(
-      `${TEST_NODE_URL}/control/machine/${TEST_VM_ID}/stop`,
-    )
+    expect(url).toBe(`${TEST_NODE_URL}/control/machine/${TEST_VM_ID}/stop`)
     expect(options.method).toBe('POST')
     expect(options.headers['X-SignedPubKey']).toBeDefined()
-    expect(
-      options.headers['X-SignedOperation'],
-    ).toBeDefined()
+    expect(options.headers['X-SignedOperation']).toBeDefined()
   })
 
   it('should return status and response text', async () => {
@@ -307,10 +211,7 @@ describe('startInstance', () => {
 
   beforeEach(async () => {
     const account = createMockAccount()
-    client = await VmClient.create(
-      account,
-      TEST_NODE_URL,
-    )
+    client = await VmClient.create(account, TEST_NODE_URL)
     mockFetch.mockClear()
     mockFetch.mockResolvedValue({
       status: 200,
@@ -323,13 +224,9 @@ describe('startInstance', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
     const [url, options] = mockFetch.mock.calls[0]
-    expect(url).toBe(
-      `${TEST_NODE_URL}/control/allocation/notify`,
-    )
+    expect(url).toBe(`${TEST_NODE_URL}/control/allocation/notify`)
     expect(options.method).toBe('POST')
-    expect(
-      options.headers['X-SignedPubKey'],
-    ).toBeUndefined()
+    expect(options.headers['X-SignedPubKey']).toBeUndefined()
 
     const body = JSON.parse(options.body)
     expect(body.instance).toBe(TEST_VM_ID)
@@ -341,10 +238,7 @@ describe('deleteBackup', () => {
 
   beforeEach(async () => {
     const account = createMockAccount()
-    client = await VmClient.create(
-      account,
-      TEST_NODE_URL,
-    )
+    client = await VmClient.create(account, TEST_NODE_URL)
     mockFetch.mockClear()
     mockFetch.mockResolvedValue({
       status: 200,
@@ -353,16 +247,11 @@ describe('deleteBackup', () => {
   })
 
   it('should reject invalid backup IDs', async () => {
-    await expect(
-      client.deleteBackup(TEST_VM_ID, 'bad id!'),
-    ).rejects.toThrow('Invalid backup ID')
+    await expect(client.deleteBackup(TEST_VM_ID, 'bad id!')).rejects.toThrow('Invalid backup ID')
   })
 
   it('should accept valid backup IDs', async () => {
-    await client.deleteBackup(
-      TEST_VM_ID,
-      'backup_2024-01-15',
-    )
+    await client.deleteBackup(TEST_VM_ID, 'backup_2024-01-15')
 
     const calledUrl = mockFetch.mock.calls[0][0] as string
     expect(calledUrl).toContain('/backup/backup_2024-01-15')
@@ -374,10 +263,7 @@ describe('reinstallInstance', () => {
 
   beforeEach(async () => {
     const account = createMockAccount()
-    client = await VmClient.create(
-      account,
-      TEST_NODE_URL,
-    )
+    client = await VmClient.create(account, TEST_NODE_URL)
     mockFetch.mockClear()
     mockFetch.mockResolvedValue({
       status: 200,
@@ -405,61 +291,37 @@ describe('streamLogs', () => {
 
   beforeEach(async () => {
     const account = createMockAccount()
-    client = await VmClient.create(
-      account,
-      TEST_NODE_URL,
-    )
+    client = await VmClient.create(account, TEST_NODE_URL)
     mockFetch.mockClear()
   })
 
   it('should build correct WebSocket URL from https node URL', () => {
     const url = client.getStreamLogsUrl(TEST_VM_ID)
-    expect(url).toBe(
-      `wss://crn.example.com/control/machine/${TEST_VM_ID}/stream_logs`,
-    )
+    expect(url).toBe(`wss://crn.example.com/control/machine/${TEST_VM_ID}/stream_logs`)
   })
 
   it('should build correct WebSocket URL from http node URL', async () => {
     const account = createMockAccount()
-    const httpClient = await VmClient.create(
-      account,
-      'http://crn.example.com',
-    )
+    const httpClient = await VmClient.create(account, 'http://crn.example.com')
     const url = httpClient.getStreamLogsUrl(TEST_VM_ID)
-    expect(url).toBe(
-      `ws://crn.example.com/control/machine/${TEST_VM_ID}/stream_logs`,
-    )
+    expect(url).toBe(`ws://crn.example.com/control/machine/${TEST_VM_ID}/stream_logs`)
   })
 
   it('should build auth headers with stream_logs operation and GET method', async () => {
-    const { url, headers } = await client.buildHeaders(
-      TEST_VM_ID,
-      VmOperation.StreamLogs,
-      'GET',
-    )
+    const { url, headers } = await client.buildHeaders(TEST_VM_ID, VmOperation.StreamLogs, 'GET')
 
-    expect(url).toBe(
-      `${TEST_NODE_URL}/control/machine/${TEST_VM_ID}/stream_logs`,
-    )
+    expect(url).toBe(`${TEST_NODE_URL}/control/machine/${TEST_VM_ID}/stream_logs`)
 
-    const opHeader = JSON.parse(
-      headers['X-SignedOperation'],
-    )
-    const payloadJson = bytesToUtf8(
-      hexToBytes(opHeader.payload),
-    )
+    const opHeader = JSON.parse(headers['X-SignedOperation'])
+    const payloadJson = bytesToUtf8(hexToBytes(opHeader.payload))
     const payload = JSON.parse(payloadJson)
 
     expect(payload.method).toBe('GET')
-    expect(payload.path).toBe(
-      `/control/machine/${TEST_VM_ID}/stream_logs`,
-    )
+    expect(payload.path).toBe(`/control/machine/${TEST_VM_ID}/stream_logs`)
     expect(payload.domain).toBe('crn.example.com')
 
     expect(headers['X-SignedPubKey']).toBeDefined()
-    expect(
-      headers['X-SignedOperation'],
-    ).toBeDefined()
+    expect(headers['X-SignedOperation']).toBeDefined()
   })
 })
 
@@ -468,10 +330,7 @@ describe('reserveResources', () => {
 
   beforeEach(async () => {
     const account = createMockAccount()
-    client = await VmClient.create(
-      account,
-      TEST_NODE_URL,
-    )
+    client = await VmClient.create(account, TEST_NODE_URL)
     mockFetch.mockClear()
     mockFetch.mockResolvedValue({
       status: 200,
@@ -490,19 +349,11 @@ describe('reserveResources', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1)
     const [calledUrl, options] = mockFetch.mock.calls[0]
 
-    expect(calledUrl).toBe(
-      `${TEST_NODE_URL}/control/reserve_resources`,
-    )
+    expect(calledUrl).toBe(`${TEST_NODE_URL}/control/reserve_resources`)
     expect(options.method).toBe('POST')
-    expect(options.headers['Content-Type']).toBe(
-      'application/json',
-    )
-    expect(
-      options.headers['X-SignedPubKey'],
-    ).toBeDefined()
-    expect(
-      options.headers['X-SignedOperation'],
-    ).toBeDefined()
+    expect(options.headers['Content-Type']).toBe('application/json')
+    expect(options.headers['X-SignedPubKey']).toBeDefined()
+    expect(options.headers['X-SignedOperation']).toBeDefined()
 
     const body = JSON.parse(options.body)
     expect(body.vcpus).toBe(4)
@@ -517,17 +368,11 @@ describe('reserveResources', () => {
     await client.reserveResources({ vcpus: 1 })
 
     const [, options] = mockFetch.mock.calls[0]
-    const opHeader = JSON.parse(
-      options.headers['X-SignedOperation'],
-    )
-    const payloadJson = bytesToUtf8(
-      hexToBytes(opHeader.payload),
-    )
+    const opHeader = JSON.parse(options.headers['X-SignedOperation'])
+    const payloadJson = bytesToUtf8(hexToBytes(opHeader.payload))
     const payload = JSON.parse(payloadJson)
 
-    expect(payload.path).toBe(
-      '/control/reserve_resources',
-    )
+    expect(payload.path).toBe('/control/reserve_resources')
     expect(payload.method).toBe('POST')
     expect(payload.domain).toBe('crn.example.com')
   })

--- a/packages/client/__tests__/vmClient.test.ts
+++ b/packages/client/__tests__/vmClient.test.ts
@@ -1,0 +1,401 @@
+import { Blockchain } from '@aleph-sdk/core'
+import { Account } from '@aleph-sdk/account'
+
+import { VmClient, VmOperation } from '../src/vmClient'
+import { hexToBytes, bytesToUtf8 } from '../src/utils/hex'
+
+function createMockAccount(
+  chain: Blockchain = Blockchain.ETH,
+): Account {
+  return {
+    address: '0xTestAddress1234567890',
+    getChain: () => chain,
+    sign: jest.fn().mockResolvedValue('0xmocksignature123'),
+  } as unknown as Account
+}
+
+const TEST_NODE_URL = 'https://crn.example.com'
+const TEST_VM_ID = 'abc123def456'
+
+// Mock fetch globally
+const mockFetch = jest.fn().mockResolvedValue({
+  status: 200,
+  text: () => Promise.resolve('OK'),
+})
+global.fetch = mockFetch
+
+describe('VmClient.create', () => {
+  it('should create a VmClient with a valid URL', async () => {
+    const account = createMockAccount()
+    const client = await VmClient.create(
+      account,
+      TEST_NODE_URL,
+    )
+    expect(client).toBeInstanceOf(VmClient)
+  })
+
+  it('should strip trailing slashes from the node URL', async () => {
+    const account = createMockAccount()
+    const client = await VmClient.create(
+      account,
+      'https://crn.example.com///',
+    )
+
+    mockFetch.mockClear()
+    await client.startInstance(TEST_VM_ID)
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).toBe(
+      'https://crn.example.com/control/allocation/notify',
+    )
+  })
+
+  it('should reject an invalid URL', async () => {
+    const account = createMockAccount()
+    await expect(
+      VmClient.create(account, 'not-a-url'),
+    ).rejects.toThrow('Invalid node URL')
+  })
+})
+
+describe('X-SignedPubKey header', () => {
+  let client: VmClient
+  let account: Account
+
+  beforeEach(async () => {
+    account = createMockAccount()
+    client = await VmClient.create(
+      account,
+      TEST_NODE_URL,
+    )
+    mockFetch.mockClear()
+  })
+
+  it('should contain sender, payload, signature, and content.domain', async () => {
+    const { headers } = await client.buildHeaders(
+      TEST_VM_ID,
+      VmOperation.Stop,
+    )
+
+    const pubkeyHeader = JSON.parse(
+      headers['X-SignedPubKey'],
+    )
+
+    expect(pubkeyHeader.sender).toBe(
+      '0xTestAddress1234567890',
+    )
+    expect(pubkeyHeader.signature).toBe(
+      '0xmocksignature123',
+    )
+    expect(pubkeyHeader.content.domain).toBe(
+      TEST_NODE_URL,
+    )
+    expect(typeof pubkeyHeader.payload).toBe('string')
+  })
+
+  it('should have a payload that hex-decodes to JSON with correct fields', async () => {
+    const { headers } = await client.buildHeaders(
+      TEST_VM_ID,
+      VmOperation.Stop,
+    )
+
+    const pubkeyHeader = JSON.parse(
+      headers['X-SignedPubKey'],
+    )
+    const payloadJson = bytesToUtf8(
+      hexToBytes(pubkeyHeader.payload),
+    )
+    const payload = JSON.parse(payloadJson)
+
+    expect(payload.pubkey).toBeDefined()
+    expect(payload.pubkey.kty).toBe('EC')
+    expect(payload.pubkey.crv).toBe('P-256')
+    expect(payload.alg).toBe('ECDSA')
+    expect(payload.domain).toBe(TEST_NODE_URL)
+    expect(payload.address).toBe(
+      '0xTestAddress1234567890',
+    )
+    expect(payload.chain).toBe('ETH')
+    expect(payload.expires).toBeDefined()
+  })
+
+  it('should reuse the cached pubkey header across requests', async () => {
+    const { headers: h1 } = await client.buildHeaders(
+      TEST_VM_ID,
+      VmOperation.Stop,
+    )
+    const { headers: h2 } = await client.buildHeaders(
+      TEST_VM_ID,
+      VmOperation.Reboot,
+    )
+
+    expect(h1['X-SignedPubKey']).toBe(
+      h2['X-SignedPubKey'],
+    )
+    expect(account.sign).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('X-SignedOperation header', () => {
+  let client: VmClient
+
+  beforeEach(async () => {
+    const account = createMockAccount()
+    client = await VmClient.create(
+      account,
+      TEST_NODE_URL,
+    )
+    mockFetch.mockClear()
+  })
+
+  it('should contain a payload that hex-decodes to JSON with time, method, path, domain', async () => {
+    const { headers } = await client.buildHeaders(
+      TEST_VM_ID,
+      VmOperation.Stop,
+      'POST',
+    )
+
+    const opHeader = JSON.parse(
+      headers['X-SignedOperation'],
+    )
+    const payloadJson = bytesToUtf8(
+      hexToBytes(opHeader.payload),
+    )
+    const payload = JSON.parse(payloadJson)
+
+    expect(payload.time).toBeDefined()
+    expect(payload.method).toBe('POST')
+    expect(payload.path).toBe(
+      `/control/machine/${TEST_VM_ID}/stop`,
+    )
+    expect(payload.domain).toBe(TEST_NODE_URL)
+  })
+
+  it('should include sender and signature', async () => {
+    const { headers } = await client.buildHeaders(
+      TEST_VM_ID,
+      VmOperation.Stop,
+    )
+
+    const opHeader = JSON.parse(
+      headers['X-SignedOperation'],
+    )
+    expect(opHeader.sender).toBe(
+      '0xTestAddress1234567890',
+    )
+    expect(typeof opHeader.signature).toBe('string')
+    expect(opHeader.signature.length).toBeGreaterThan(0)
+  })
+})
+
+describe('SOL chain handling', () => {
+  it('should pass SOL chain in the pubkey payload', async () => {
+    const solAccount = createMockAccount(Blockchain.SOL)
+    ;(solAccount.sign as jest.Mock).mockResolvedValue(
+      JSON.stringify({ signature: '2gPmh' }),
+    )
+    const client = await VmClient.create(
+      solAccount,
+      TEST_NODE_URL,
+    )
+
+    const { headers } = await client.buildHeaders(
+      TEST_VM_ID,
+      VmOperation.Stop,
+    )
+
+    const pubkeyHeader = JSON.parse(
+      headers['X-SignedPubKey'],
+    )
+    const payloadJson = bytesToUtf8(
+      hexToBytes(pubkeyHeader.payload),
+    )
+    const payload = JSON.parse(payloadJson)
+
+    expect(payload.chain).toBe('SOL')
+  })
+
+  it('should call sign with hex-encoded UTF-8 bytes for SOL verification buffer', async () => {
+    const solAccount = createMockAccount(Blockchain.SOL)
+    // SOL sign returns a JSON signature with base58
+    ;(solAccount.sign as jest.Mock).mockResolvedValue(
+      JSON.stringify({
+        signature: '2gPmh',
+      }),
+    )
+
+    const client = await VmClient.create(
+      solAccount,
+      TEST_NODE_URL,
+    )
+
+    await client.buildHeaders(
+      TEST_VM_ID,
+      VmOperation.Stop,
+    )
+
+    expect(solAccount.sign).toHaveBeenCalledTimes(1)
+    const signable = (solAccount.sign as jest.Mock).mock
+      .calls[0][0]
+    const verBuf = signable.getVerificationBuffer()
+
+    // For SOL, the verification buffer should be UTF-8
+    // bytes of the hex-encoded payload string
+    const bufStr = verBuf.toString()
+    // The hex string should contain only hex characters
+    expect(bufStr).toMatch(/^[0-9a-f]+$/)
+
+    // And the pubkey header signature should be
+    // 0x-prefixed hex (converted from base58)
+    const pubkeyHeader = JSON.parse(
+      (
+        await client.buildHeaders(
+          TEST_VM_ID,
+          VmOperation.Stop,
+        )
+      ).headers['X-SignedPubKey'],
+    )
+    expect(pubkeyHeader.signature).toMatch(/^0x[0-9a-f]+$/)
+  })
+})
+
+describe('performOperation', () => {
+  let client: VmClient
+
+  beforeEach(async () => {
+    const account = createMockAccount()
+    client = await VmClient.create(
+      account,
+      TEST_NODE_URL,
+    )
+    mockFetch.mockClear()
+    mockFetch.mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve('OK'),
+    })
+  })
+
+  it('should call fetch with correct URL and headers', async () => {
+    await client.stopInstance(TEST_VM_ID)
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [url, options] = mockFetch.mock.calls[0]
+    expect(url).toBe(
+      `${TEST_NODE_URL}/control/machine/${TEST_VM_ID}/stop`,
+    )
+    expect(options.method).toBe('POST')
+    expect(options.headers['X-SignedPubKey']).toBeDefined()
+    expect(
+      options.headers['X-SignedOperation'],
+    ).toBeDefined()
+  })
+
+  it('should return status and response text', async () => {
+    mockFetch.mockResolvedValueOnce({
+      status: 204,
+      text: () => Promise.resolve('No Content'),
+    })
+
+    const result = await client.stopInstance(TEST_VM_ID)
+    expect(result.status).toBe(204)
+    expect(result.response).toBe('No Content')
+  })
+})
+
+describe('startInstance', () => {
+  let client: VmClient
+
+  beforeEach(async () => {
+    const account = createMockAccount()
+    client = await VmClient.create(
+      account,
+      TEST_NODE_URL,
+    )
+    mockFetch.mockClear()
+    mockFetch.mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve('OK'),
+    })
+  })
+
+  it('should POST to /control/allocation/notify without auth headers', async () => {
+    await client.startInstance(TEST_VM_ID)
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [url, options] = mockFetch.mock.calls[0]
+    expect(url).toBe(
+      `${TEST_NODE_URL}/control/allocation/notify`,
+    )
+    expect(options.method).toBe('POST')
+    expect(
+      options.headers['X-SignedPubKey'],
+    ).toBeUndefined()
+
+    const body = JSON.parse(options.body)
+    expect(body.instance).toBe(TEST_VM_ID)
+  })
+})
+
+describe('deleteBackup', () => {
+  let client: VmClient
+
+  beforeEach(async () => {
+    const account = createMockAccount()
+    client = await VmClient.create(
+      account,
+      TEST_NODE_URL,
+    )
+    mockFetch.mockClear()
+    mockFetch.mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve('OK'),
+    })
+  })
+
+  it('should reject invalid backup IDs', async () => {
+    await expect(
+      client.deleteBackup(TEST_VM_ID, 'bad id!'),
+    ).rejects.toThrow('Invalid backup ID')
+  })
+
+  it('should accept valid backup IDs', async () => {
+    await client.deleteBackup(
+      TEST_VM_ID,
+      'backup_2024-01-15',
+    )
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).toContain('/backup/backup_2024-01-15')
+  })
+})
+
+describe('reinstallInstance', () => {
+  let client: VmClient
+
+  beforeEach(async () => {
+    const account = createMockAccount()
+    client = await VmClient.create(
+      account,
+      TEST_NODE_URL,
+    )
+    mockFetch.mockClear()
+    mockFetch.mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve('OK'),
+    })
+  })
+
+  it('should include erase_volumes param when specified', async () => {
+    await client.reinstallInstance(TEST_VM_ID, true)
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).toContain('erase_volumes=true')
+  })
+
+  it('should omit erase_volumes param when not specified', async () => {
+    await client.reinstallInstance(TEST_VM_ID)
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).not.toContain('erase_volumes')
+  })
+})

--- a/packages/client/__tests__/vmClient.test.ts
+++ b/packages/client/__tests__/vmClient.test.ts
@@ -399,3 +399,136 @@ describe('reinstallInstance', () => {
     expect(calledUrl).not.toContain('erase_volumes')
   })
 })
+
+describe('streamLogs', () => {
+  let client: VmClient
+
+  beforeEach(async () => {
+    const account = createMockAccount()
+    client = await VmClient.create(
+      account,
+      TEST_NODE_URL,
+    )
+    mockFetch.mockClear()
+  })
+
+  it('should build correct WebSocket URL from https node URL', () => {
+    const url = client.getStreamLogsUrl(TEST_VM_ID)
+    expect(url).toBe(
+      `wss://crn.example.com/control/machine/${TEST_VM_ID}/stream_logs`,
+    )
+  })
+
+  it('should build correct WebSocket URL from http node URL', async () => {
+    const account = createMockAccount()
+    const httpClient = await VmClient.create(
+      account,
+      'http://crn.example.com',
+    )
+    const url = httpClient.getStreamLogsUrl(TEST_VM_ID)
+    expect(url).toBe(
+      `ws://crn.example.com/control/machine/${TEST_VM_ID}/stream_logs`,
+    )
+  })
+
+  it('should build auth headers with stream_logs operation and GET method', async () => {
+    const { url, headers } = await client.buildHeaders(
+      TEST_VM_ID,
+      VmOperation.StreamLogs,
+      'GET',
+    )
+
+    expect(url).toBe(
+      `${TEST_NODE_URL}/control/machine/${TEST_VM_ID}/stream_logs`,
+    )
+
+    const opHeader = JSON.parse(
+      headers['X-SignedOperation'],
+    )
+    const payloadJson = bytesToUtf8(
+      hexToBytes(opHeader.payload),
+    )
+    const payload = JSON.parse(payloadJson)
+
+    expect(payload.method).toBe('GET')
+    expect(payload.path).toBe(
+      `/control/machine/${TEST_VM_ID}/stream_logs`,
+    )
+    expect(payload.domain).toBe('crn.example.com')
+
+    expect(headers['X-SignedPubKey']).toBeDefined()
+    expect(
+      headers['X-SignedOperation'],
+    ).toBeDefined()
+  })
+})
+
+describe('reserveResources', () => {
+  let client: VmClient
+
+  beforeEach(async () => {
+    const account = createMockAccount()
+    client = await VmClient.create(
+      account,
+      TEST_NODE_URL,
+    )
+    mockFetch.mockClear()
+    mockFetch.mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve('{"reserved": true}'),
+    })
+  })
+
+  it('should POST to /control/reserve_resources with auth headers and JSON body', async () => {
+    const config = {
+      vcpus: 4,
+      memory_mib: 2048,
+      storage_mib: 10240,
+    }
+    const result = await client.reserveResources(config)
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [calledUrl, options] = mockFetch.mock.calls[0]
+
+    expect(calledUrl).toBe(
+      `${TEST_NODE_URL}/control/reserve_resources`,
+    )
+    expect(options.method).toBe('POST')
+    expect(options.headers['Content-Type']).toBe(
+      'application/json',
+    )
+    expect(
+      options.headers['X-SignedPubKey'],
+    ).toBeDefined()
+    expect(
+      options.headers['X-SignedOperation'],
+    ).toBeDefined()
+
+    const body = JSON.parse(options.body)
+    expect(body.vcpus).toBe(4)
+    expect(body.memory_mib).toBe(2048)
+    expect(body.storage_mib).toBe(10240)
+
+    expect(result.status).toBe(200)
+    expect(result.response).toBe('{"reserved": true}')
+  })
+
+  it('should sign the operation with the /control/reserve_resources path', async () => {
+    await client.reserveResources({ vcpus: 1 })
+
+    const [, options] = mockFetch.mock.calls[0]
+    const opHeader = JSON.parse(
+      options.headers['X-SignedOperation'],
+    )
+    const payloadJson = bytesToUtf8(
+      hexToBytes(opHeader.payload),
+    )
+    const payload = JSON.parse(payloadJson)
+
+    expect(payload.path).toBe(
+      '/control/reserve_resources',
+    )
+    expect(payload.method).toBe('POST')
+    expect(payload.domain).toBe('crn.example.com')
+  })
+})

--- a/packages/client/__tests__/vmClient.test.ts
+++ b/packages/client/__tests__/vmClient.test.ts
@@ -88,7 +88,7 @@ describe('X-SignedPubKey header', () => {
       '0xmocksignature123',
     )
     expect(pubkeyHeader.content.domain).toBe(
-      TEST_NODE_URL,
+      'crn.example.com',
     )
     expect(typeof pubkeyHeader.payload).toBe('string')
   })
@@ -111,7 +111,7 @@ describe('X-SignedPubKey header', () => {
     expect(payload.pubkey.kty).toBe('EC')
     expect(payload.pubkey.crv).toBe('P-256')
     expect(payload.alg).toBe('ECDSA')
-    expect(payload.domain).toBe(TEST_NODE_URL)
+    expect(payload.domain).toBe('crn.example.com')
     expect(payload.address).toBe(
       '0xTestAddress1234567890',
     )
@@ -168,7 +168,7 @@ describe('X-SignedOperation header', () => {
     expect(payload.path).toBe(
       `/control/machine/${TEST_VM_ID}/stop`,
     )
-    expect(payload.domain).toBe(TEST_NODE_URL)
+    expect(payload.domain).toBe('crn.example.com')
   })
 
   it('should include sender and signature', async () => {

--- a/packages/client/__tests__/vmClient.test.ts
+++ b/packages/client/__tests__/vmClient.test.ts
@@ -233,6 +233,77 @@ describe('startInstance', () => {
   })
 })
 
+describe('createBackup', () => {
+  let client: VmClient
+
+  beforeEach(async () => {
+    const account = createMockAccount()
+    client = await VmClient.create(account, TEST_NODE_URL)
+    mockFetch.mockClear()
+    mockFetch.mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve('{"backup_id": "bk_123"}'),
+    })
+  })
+
+  it('should POST to backup endpoint with no params by default', async () => {
+    await client.createBackup(TEST_VM_ID)
+
+    const [calledUrl, options] = mockFetch.mock.calls[0]
+    expect(calledUrl).toBe(`${TEST_NODE_URL}/control/machine/${TEST_VM_ID}/backup`)
+    expect(options.method).toBe('POST')
+  })
+
+  it('should include include_volumes param when specified', async () => {
+    await client.createBackup(TEST_VM_ID, { includeVolumes: true })
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).toContain('include_volumes=true')
+  })
+
+  it('should include skip_fsfreeze param when specified', async () => {
+    await client.createBackup(TEST_VM_ID, { skipFsfreeze: true })
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).toContain('skip_fsfreeze=true')
+  })
+
+  it('should include both params when both specified', async () => {
+    await client.createBackup(TEST_VM_ID, {
+      includeVolumes: false,
+      skipFsfreeze: true,
+    })
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string
+    expect(calledUrl).toContain('include_volumes=false')
+    expect(calledUrl).toContain('skip_fsfreeze=true')
+  })
+})
+
+describe('getBackup', () => {
+  let client: VmClient
+
+  beforeEach(async () => {
+    const account = createMockAccount()
+    client = await VmClient.create(account, TEST_NODE_URL)
+    mockFetch.mockClear()
+    mockFetch.mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve('[{"id": "bk_123"}]'),
+    })
+  })
+
+  it('should GET the backup endpoint', async () => {
+    const result = await client.getBackup(TEST_VM_ID)
+
+    const [calledUrl, options] = mockFetch.mock.calls[0]
+    expect(calledUrl).toBe(`${TEST_NODE_URL}/control/machine/${TEST_VM_ID}/backup`)
+    expect(options.method).toBe('GET')
+    expect(result.status).toBe(200)
+    expect(result.response).toBe('[{"id": "bk_123"}]')
+  })
+})
+
 describe('deleteBackup', () => {
   let client: VmClient
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,2 +1,3 @@
 export * from './httpClient'
 export * from './authenticatedHttpClient'
+export * from './vmClient'

--- a/packages/client/src/utils/hex.ts
+++ b/packages/client/src/utils/hex.ts
@@ -1,0 +1,23 @@
+export function bytesToHex(bytes: Uint8Array): string {
+  let hex = ''
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, '0')
+  }
+  return hex
+}
+
+export function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16)
+  }
+  return bytes
+}
+
+export function utf8ToBytes(str: string): Uint8Array {
+  return new TextEncoder().encode(str)
+}
+
+export function bytesToUtf8(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes)
+}

--- a/packages/client/src/utils/hex.ts
+++ b/packages/client/src/utils/hex.ts
@@ -7,9 +7,16 @@ export function bytesToHex(bytes: Uint8Array): string {
 }
 
 export function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) {
+    throw new Error(`Invalid hex string: odd length (${hex.length})`)
+  }
   const bytes = new Uint8Array(hex.length / 2)
   for (let i = 0; i < hex.length; i += 2) {
-    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16)
+    const byte = parseInt(hex.substring(i, i + 2), 16)
+    if (Number.isNaN(byte)) {
+      throw new Error(`Invalid hex character at position ${i}: ${hex.substring(i, i + 2)}`)
+    }
+    bytes[i / 2] = byte
   }
   return bytes
 }

--- a/packages/client/src/vmClient.ts
+++ b/packages/client/src/vmClient.ts
@@ -100,6 +100,10 @@ export class VmClient {
     this.ephemeralKey = ephemeralKey
   }
 
+  get nodeDomain(): string {
+    return new URL(this.nodeUrl).hostname
+  }
+
   static async create(
     account: Account,
     nodeUrl: string,
@@ -113,7 +117,7 @@ export class VmClient {
 
     const ephemeralKey = await crypto.subtle.generateKey(
       EPHEMERAL_KEY_PARAMS,
-      false,
+      true,
       ['sign', 'verify'],
     )
 
@@ -129,9 +133,9 @@ export class VmClient {
     const payload = {
       pubkey: publicJwk,
       alg: 'ECDSA',
-      domain: this.nodeUrl,
+      domain: this.nodeDomain,
       address: this.account.address,
-      chain: this.account.getChain(),
+      chain: this.account.getChain() === Blockchain.SOL ? 'SOL' : 'ETH',
       expires: new Date(
         Date.now() + PUBKEY_TTL_MS,
       ).toISOString(),
@@ -173,7 +177,7 @@ export class VmClient {
       sender: this.account.address,
       payload: hexPayload,
       signature,
-      content: { domain: this.nodeUrl },
+      content: { domain: this.nodeDomain },
     })
 
     return header
@@ -232,7 +236,7 @@ export class VmClient {
       time: new Date().toISOString(),
       method,
       path,
-      domain: this.nodeUrl,
+      domain: this.nodeDomain,
     })
 
     const hexPayload = bytesToHex(
@@ -246,7 +250,7 @@ export class VmClient {
       sender: this.account.address,
       payload: hexPayload,
       signature,
-      content: { domain: this.nodeUrl },
+      content: { domain: this.nodeDomain },
     })
 
     return {

--- a/packages/client/src/vmClient.ts
+++ b/packages/client/src/vmClient.ts
@@ -1,5 +1,4 @@
-import { Account } from '@aleph-sdk/account'
-import { SignableMessage } from '@aleph-sdk/account'
+import { Account, SignableMessage } from '@aleph-sdk/account'
 import { Blockchain } from '@aleph-sdk/core'
 
 import { bytesToHex, utf8ToBytes } from './utils/hex'
@@ -18,7 +17,7 @@ export enum VmOperation {
 }
 
 export type VmOperationResult = {
-  status: number | null
+  status: number
   response: string
 }
 

--- a/packages/client/src/vmClient.ts
+++ b/packages/client/src/vmClient.ts
@@ -1,6 +1,6 @@
-import { Blockchain } from '@aleph-sdk/core'
 import { Account } from '@aleph-sdk/account'
 import { SignableMessage } from '@aleph-sdk/account'
+import { Blockchain } from '@aleph-sdk/core'
 
 import { bytesToHex, utf8ToBytes } from './utils/hex'
 
@@ -30,8 +30,7 @@ export type LogEntry = {
 
 // --- Base58 decoding (for Solana signature conversion) ---
 
-const BASE58_ALPHABET =
-  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
 function base58Decode(input: string): Uint8Array {
   if (input.length === 0) return new Uint8Array(0)
@@ -40,9 +39,7 @@ function base58Decode(input: string): Uint8Array {
   for (let i = 0; i < input.length; i++) {
     const charIndex = BASE58_ALPHABET.indexOf(input[i])
     if (charIndex < 0) {
-      throw new Error(
-        `Invalid base58 character: ${input[i]}`,
-      )
+      throw new Error(`Invalid base58 character: ${input[i]}`)
     }
     let carry = charIndex
     for (let j = 0; j < bytes.length; j++) {
@@ -90,11 +87,7 @@ export class VmClient {
   private readonly ephemeralKey: CryptoKeyPair
   private cachedPubkeyHeader: string | null = null
 
-  private constructor(
-    account: Account,
-    nodeUrl: string,
-    ephemeralKey: CryptoKeyPair,
-  ) {
+  private constructor(account: Account, nodeUrl: string, ephemeralKey: CryptoKeyPair) {
     this.account = account
     this.nodeUrl = nodeUrl
     this.ephemeralKey = ephemeralKey
@@ -104,10 +97,7 @@ export class VmClient {
     return new URL(this.nodeUrl).hostname
   }
 
-  static async create(
-    account: Account,
-    nodeUrl: string,
-  ): Promise<VmClient> {
+  static async create(account: Account, nodeUrl: string): Promise<VmClient> {
     const normalized = nodeUrl.replace(/\/+\s*$/, '')
     try {
       new URL(normalized)
@@ -115,20 +105,13 @@ export class VmClient {
       throw new Error(`Invalid node URL: ${nodeUrl}`)
     }
 
-    const ephemeralKey = await crypto.subtle.generateKey(
-      EPHEMERAL_KEY_PARAMS,
-      true,
-      ['sign', 'verify'],
-    )
+    const ephemeralKey = await crypto.subtle.generateKey(EPHEMERAL_KEY_PARAMS, true, ['sign', 'verify'])
 
     return new VmClient(account, normalized, ephemeralKey)
   }
 
   private async buildPubkeyPayload(): Promise<string> {
-    const publicJwk = await crypto.subtle.exportKey(
-      'jwk',
-      this.ephemeralKey.publicKey,
-    )
+    const publicJwk = await crypto.subtle.exportKey('jwk', this.ephemeralKey.publicKey)
 
     const payload = {
       pubkey: publicJwk,
@@ -136,17 +119,13 @@ export class VmClient {
       domain: this.nodeDomain,
       address: this.account.address,
       chain: this.account.getChain() === Blockchain.SOL ? 'SOL' : 'ETH',
-      expires: new Date(
-        Date.now() + PUBKEY_TTL_MS,
-      ).toISOString(),
+      expires: new Date(Date.now() + PUBKEY_TTL_MS).toISOString(),
     }
 
     return JSON.stringify(payload)
   }
 
-  private async buildPubkeySignatureHeader(
-    payloadJson: string,
-  ): Promise<string> {
+  private async buildPubkeySignatureHeader(payloadJson: string): Promise<string> {
     const jsonBytes = utf8ToBytes(payloadJson)
     const hexPayload = bytesToHex(jsonBytes)
 
@@ -154,9 +133,7 @@ export class VmClient {
     let verificationBuffer: Buffer
 
     if (chain === Blockchain.SOL) {
-      verificationBuffer = Buffer.from(
-        utf8ToBytes(hexPayload),
-      )
+      verificationBuffer = Buffer.from(utf8ToBytes(hexPayload))
     } else {
       verificationBuffer = Buffer.from(jsonBytes)
     }
@@ -189,42 +166,28 @@ export class VmClient {
     }
 
     const payloadJson = await this.buildPubkeyPayload()
-    const header = await this.buildPubkeySignatureHeader(
-      payloadJson,
-    )
+    const header = await this.buildPubkeySignatureHeader(payloadJson)
 
     this.cachedPubkeyHeader = header
     return header
   }
 
-  private async signControlPayload(
-    payload: string,
-  ): Promise<string> {
+  private async signControlPayload(payload: string): Promise<string> {
     const payloadBytes = utf8ToBytes(payload)
 
-    const signatureBuffer = await crypto.subtle.sign(
-      SIGN_ALGORITHM,
-      this.ephemeralKey.privateKey,
-      payloadBytes,
-    )
+    const signatureBuffer = await crypto.subtle.sign(SIGN_ALGORITHM, this.ephemeralKey.privateKey, payloadBytes)
 
     return bytesToHex(new Uint8Array(signatureBuffer))
   }
 
-  private convertSolSignatureToHex(
-    jsonSignature: string,
-  ): string {
+  private convertSolSignatureToHex(jsonSignature: string): string {
     const parsed = JSON.parse(jsonSignature)
-    const signatureStr: string =
-      parsed.signature ?? parsed
+    const signatureStr: string = parsed.signature ?? parsed
     const decoded = base58Decode(signatureStr)
     return '0x' + bytesToHex(decoded)
   }
 
-  private async buildAuthHeaders(
-    path: string,
-    method: string,
-  ): Promise<Record<string, string>> {
+  private async buildAuthHeaders(path: string, method: string): Promise<Record<string, string>> {
     const pubkeyHeader = await this.ensurePubkeyHeader()
 
     const operationPayload = JSON.stringify({
@@ -234,12 +197,8 @@ export class VmClient {
       domain: this.nodeDomain,
     })
 
-    const hexPayload = bytesToHex(
-      utf8ToBytes(operationPayload),
-    )
-    const signature = await this.signControlPayload(
-      operationPayload,
-    )
+    const hexPayload = bytesToHex(utf8ToBytes(operationPayload))
+    const signature = await this.signControlPayload(operationPayload)
 
     const operationHeader = JSON.stringify({
       sender: this.account.address,
@@ -259,13 +218,9 @@ export class VmClient {
     operation: VmOperation,
     method: string = 'POST',
   ): Promise<{ url: string; headers: Record<string, string> }> {
-    const path =
-      `/control/machine/${vmId}/${operation}`
+    const path = `/control/machine/${vmId}/${operation}`
     const url = `${this.nodeUrl}${path}`
-    const headers = await this.buildAuthHeaders(
-      path,
-      method,
-    )
+    const headers = await this.buildAuthHeaders(path, method)
 
     return { url, headers }
   }
@@ -280,17 +235,11 @@ export class VmClient {
     },
   ): Promise<VmOperationResult> {
     const method = options?.method ?? 'POST'
-    const { url, headers } = await this.buildHeaders(
-      vmId,
-      operation,
-      method,
-    )
+    const { url, headers } = await this.buildHeaders(vmId, operation, method)
 
     let fullUrl = url
     if (options?.params) {
-      const searchParams = new URLSearchParams(
-        options.params,
-      )
+      const searchParams = new URLSearchParams(options.params)
       fullUrl = `${url}?${searchParams.toString()}`
     }
 
@@ -300,12 +249,8 @@ export class VmClient {
     }
 
     if (options?.jsonData !== undefined) {
-      ;(
-        fetchOptions.headers as Record<string, string>
-      )['Content-Type'] = 'application/json'
-      fetchOptions.body = JSON.stringify(
-        options.jsonData,
-      )
+      ;(fetchOptions.headers as Record<string, string>)['Content-Type'] = 'application/json'
+      fetchOptions.body = JSON.stringify(options.jsonData)
     }
 
     const resp = await fetch(fullUrl, fetchOptions)
@@ -317,9 +262,7 @@ export class VmClient {
     }
   }
 
-  async startInstance(
-    vmId: string,
-  ): Promise<VmOperationResult> {
+  async startInstance(vmId: string): Promise<VmOperationResult> {
     const url = `${this.nodeUrl}/control/allocation/notify`
     const resp = await fetch(url, {
       method: 'POST',
@@ -330,56 +273,27 @@ export class VmClient {
     return { status: resp.status, response: responseText }
   }
 
-  async stopInstance(
-    vmId: string,
-  ): Promise<VmOperationResult> {
-    return this.performOperation(
-      vmId,
-      VmOperation.Stop,
-    )
+  async stopInstance(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Stop)
   }
 
-  async rebootInstance(
-    vmId: string,
-  ): Promise<VmOperationResult> {
-    return this.performOperation(
-      vmId,
-      VmOperation.Reboot,
-    )
+  async rebootInstance(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Reboot)
   }
 
-  async eraseInstance(
-    vmId: string,
-  ): Promise<VmOperationResult> {
-    return this.performOperation(
-      vmId,
-      VmOperation.Erase,
-    )
+  async eraseInstance(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Erase)
   }
 
-  async expireInstance(
-    vmId: string,
-  ): Promise<VmOperationResult> {
-    return this.performOperation(
-      vmId,
-      VmOperation.Expire,
-    )
+  async expireInstance(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Expire)
   }
 
-  async reinstallInstance(
-    vmId: string,
-    eraseVolumes?: boolean,
-  ): Promise<VmOperationResult> {
+  async reinstallInstance(vmId: string, eraseVolumes?: boolean): Promise<VmOperationResult> {
     const params: Record<string, string> | undefined =
-      eraseVolumes !== undefined
-        ? { erase_volumes: String(eraseVolumes) }
-        : undefined
+      eraseVolumes !== undefined ? { erase_volumes: String(eraseVolumes) } : undefined
 
-    return this.performOperation(
-      vmId,
-      VmOperation.Reinstall,
-      { params },
-    )
+    return this.performOperation(vmId, VmOperation.Reinstall, { params })
   }
 
   async createBackup(
@@ -391,42 +305,22 @@ export class VmClient {
   ): Promise<VmOperationResult> {
     const params: Record<string, string> = {}
     if (options?.includeVolumes !== undefined) {
-      params['include_volumes'] = String(
-        options.includeVolumes,
-      )
+      params['include_volumes'] = String(options.includeVolumes)
     }
     if (options?.skipFsfreeze !== undefined) {
-      params['skip_fsfreeze'] = String(
-        options.skipFsfreeze,
-      )
+      params['skip_fsfreeze'] = String(options.skipFsfreeze)
     }
 
-    return this.performOperation(
-      vmId,
-      VmOperation.Backup,
-      {
-        params:
-          Object.keys(params).length > 0
-            ? params
-            : undefined,
-      },
-    )
+    return this.performOperation(vmId, VmOperation.Backup, {
+      params: Object.keys(params).length > 0 ? params : undefined,
+    })
   }
 
-  async getBackup(
-    vmId: string,
-  ): Promise<VmOperationResult> {
-    return this.performOperation(
-      vmId,
-      VmOperation.Backup,
-      { method: 'GET' },
-    )
+  async getBackup(vmId: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Backup, { method: 'GET' })
   }
 
-  async deleteBackup(
-    vmId: string,
-    backupId: string,
-  ): Promise<VmOperationResult> {
+  async deleteBackup(vmId: string, backupId: string): Promise<VmOperationResult> {
     if (!/^[a-zA-Z0-9_-]+$/.test(backupId)) {
       throw new Error(
         `Invalid backup ID: ${backupId}. ` +
@@ -435,11 +329,7 @@ export class VmClient {
       )
     }
 
-    const { url, headers } = await this.buildHeaders(
-      vmId,
-      VmOperation.Backup,
-      'DELETE',
-    )
+    const { url, headers } = await this.buildHeaders(vmId, VmOperation.Backup, 'DELETE')
 
     const resp = await fetch(`${url}/${backupId}`, {
       method: 'DELETE',
@@ -449,26 +339,12 @@ export class VmClient {
     return { status: resp.status, response: responseText }
   }
 
-  async restoreFromVolume(
-    vmId: string,
-    volumeRef: string,
-  ): Promise<VmOperationResult> {
-    return this.performOperation(
-      vmId,
-      VmOperation.Restore,
-      { jsonData: { volume_ref: volumeRef } },
-    )
+  async restoreFromVolume(vmId: string, volumeRef: string): Promise<VmOperationResult> {
+    return this.performOperation(vmId, VmOperation.Restore, { jsonData: { volume_ref: volumeRef } })
   }
 
-  async restoreFromFile(
-    vmId: string,
-    rootfsData: Blob,
-  ): Promise<VmOperationResult> {
-    const { url, headers } = await this.buildHeaders(
-      vmId,
-      VmOperation.Restore,
-      'POST',
-    )
+  async restoreFromFile(vmId: string, rootfsData: Blob): Promise<VmOperationResult> {
+    const { url, headers } = await this.buildHeaders(vmId, VmOperation.Restore, 'POST')
 
     const formData = new FormData()
     formData.append('rootfs', rootfsData)
@@ -482,33 +358,17 @@ export class VmClient {
     return { status: resp.status, response: responseText }
   }
 
-  async getRestoreEndpoint(
-    vmId: string,
-  ): Promise<{ url: string; headers: Record<string, string> }> {
-    return this.buildHeaders(
-      vmId,
-      VmOperation.Restore,
-      'POST',
-    )
+  async getRestoreEndpoint(vmId: string): Promise<{ url: string; headers: Record<string, string> }> {
+    return this.buildHeaders(vmId, VmOperation.Restore, 'POST')
   }
 
   getStreamLogsUrl(vmId: string): string {
-    const wsBase = this.nodeUrl.replace(
-      /^http/,
-      'ws',
-    )
+    const wsBase = this.nodeUrl.replace(/^http/, 'ws')
     return `${wsBase}/control/machine/${vmId}/stream_logs`
   }
 
-  async *streamLogs(
-    vmId: string,
-    abort?: AbortSignal,
-  ): AsyncGenerator<LogEntry> {
-    const { headers } = await this.buildHeaders(
-      vmId,
-      VmOperation.StreamLogs,
-      'GET',
-    )
+  async *streamLogs(vmId: string, abort?: AbortSignal): AsyncGenerator<LogEntry> {
+    const { headers } = await this.buildHeaders(vmId, VmOperation.StreamLogs, 'GET')
 
     const wsUrl = this.getStreamLogsUrl(vmId)
     const ws = new WebSocket(wsUrl)
@@ -521,10 +381,7 @@ export class VmClient {
     const cleanup = () => {
       done = true
       if (resolve) resolve()
-      if (
-        ws.readyState === WebSocket.OPEN ||
-        ws.readyState === WebSocket.CONNECTING
-      ) {
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
         ws.close()
       }
     }
@@ -532,21 +389,15 @@ export class VmClient {
     ws.onopen = () => {
       const authMessage = JSON.stringify({
         auth: {
-          'X-SignedPubKey': JSON.parse(
-            headers['X-SignedPubKey'],
-          ),
-          'X-SignedOperation': JSON.parse(
-            headers['X-SignedOperation'],
-          ),
+          'X-SignedPubKey': JSON.parse(headers['X-SignedPubKey']),
+          'X-SignedOperation': JSON.parse(headers['X-SignedOperation']),
         },
       })
       ws.send(authMessage)
     }
 
     ws.onmessage = (event: MessageEvent) => {
-      const entry = JSON.parse(
-        String(event.data),
-      ) as LogEntry
+      const entry = JSON.parse(String(event.data)) as LogEntry
       messageQueue.push(entry)
       if (resolve) resolve()
     }
@@ -561,11 +412,7 @@ export class VmClient {
     }
 
     if (abort) {
-      abort.addEventListener(
-        'abort',
-        () => cleanup(),
-        { once: true },
-      )
+      abort.addEventListener('abort', () => cleanup(), { once: true })
     }
 
     try {
@@ -586,15 +433,10 @@ export class VmClient {
     }
   }
 
-  async reserveResources(
-    config: Record<string, unknown>,
-  ): Promise<VmOperationResult> {
+  async reserveResources(config: Record<string, unknown>): Promise<VmOperationResult> {
     const path = '/control/reserve_resources'
     const url = `${this.nodeUrl}${path}`
-    const headers = await this.buildAuthHeaders(
-      path,
-      'POST',
-    )
+    const headers = await this.buildAuthHeaders(path, 'POST')
 
     const resp = await fetch(url, {
       method: 'POST',

--- a/packages/client/src/vmClient.ts
+++ b/packages/client/src/vmClient.ts
@@ -15,7 +15,6 @@ export enum VmOperation {
   Backup = 'backup',
   Restore = 'restore',
   StreamLogs = 'stream_logs',
-  Update = 'update',
 }
 
 export type VmOperationResult = {
@@ -86,6 +85,7 @@ export class VmClient {
   private readonly nodeUrl: string
   private readonly ephemeralKey: CryptoKeyPair
   private cachedPubkeyHeader: string | null = null
+  private cachedPubkeyExpiry: number = 0
 
   private constructor(account: Account, nodeUrl: string, ephemeralKey: CryptoKeyPair) {
     this.account = account
@@ -161,7 +161,7 @@ export class VmClient {
   }
 
   async ensurePubkeyHeader(): Promise<string> {
-    if (this.cachedPubkeyHeader) {
+    if (this.cachedPubkeyHeader && Date.now() < this.cachedPubkeyExpiry) {
       return this.cachedPubkeyHeader
     }
 
@@ -169,6 +169,7 @@ export class VmClient {
     const header = await this.buildPubkeySignatureHeader(payloadJson)
 
     this.cachedPubkeyHeader = header
+    this.cachedPubkeyExpiry = Date.now() + PUBKEY_TTL_MS
     return header
   }
 
@@ -182,7 +183,10 @@ export class VmClient {
 
   private convertSolSignatureToHex(jsonSignature: string): string {
     const parsed = JSON.parse(jsonSignature)
-    const signatureStr: string = parsed.signature ?? parsed
+    const signatureStr = typeof parsed === 'string' ? parsed : parsed?.signature
+    if (typeof signatureStr !== 'string') {
+      throw new Error('SOL signature must be a string or { signature: string }')
+    }
     const decoded = base58Decode(signatureStr)
     return '0x' + bytesToHex(decoded)
   }
@@ -329,12 +333,11 @@ export class VmClient {
       )
     }
 
-    const { url, headers } = await this.buildHeaders(vmId, VmOperation.Backup, 'DELETE')
+    const path = `/control/machine/${vmId}/backup/${backupId}`
+    const url = `${this.nodeUrl}${path}`
+    const headers = await this.buildAuthHeaders(path, 'DELETE')
 
-    const resp = await fetch(`${url}/${backupId}`, {
-      method: 'DELETE',
-      headers,
-    })
+    const resp = await fetch(url, { method: 'DELETE', headers })
     const responseText = await resp.text()
     return { status: resp.status, response: responseText }
   }
@@ -403,7 +406,7 @@ export class VmClient {
     }
 
     ws.onerror = () => {
-      error = new Error('WebSocket error')
+      error = new Error(`WebSocket error connecting to ${wsUrl}`)
       cleanup()
     }
 

--- a/packages/client/src/vmClient.ts
+++ b/packages/client/src/vmClient.ts
@@ -1,0 +1,482 @@
+import { Blockchain } from '@aleph-sdk/core'
+import { Account } from '@aleph-sdk/account'
+import { SignableMessage } from '@aleph-sdk/account'
+
+import { bytesToHex, utf8ToBytes } from './utils/hex'
+
+// --- Types ---
+
+export enum VmOperation {
+  Stop = 'stop',
+  Reboot = 'reboot',
+  Erase = 'erase',
+  Expire = 'expire',
+  Reinstall = 'reinstall',
+  Backup = 'backup',
+  Restore = 'restore',
+  StreamLogs = 'stream_logs',
+  Update = 'update',
+}
+
+export type VmOperationResult = {
+  status: number | null
+  response: string
+}
+
+export type LogEntry = {
+  type: 'stdout' | 'stderr'
+  message: string
+}
+
+// --- Base58 decoding (for Solana signature conversion) ---
+
+const BASE58_ALPHABET =
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+function base58Decode(input: string): Uint8Array {
+  if (input.length === 0) return new Uint8Array(0)
+
+  const bytes = [0]
+  for (let i = 0; i < input.length; i++) {
+    const charIndex = BASE58_ALPHABET.indexOf(input[i])
+    if (charIndex < 0) {
+      throw new Error(
+        `Invalid base58 character: ${input[i]}`,
+      )
+    }
+    let carry = charIndex
+    for (let j = 0; j < bytes.length; j++) {
+      carry += bytes[j] * 58
+      bytes[j] = carry & 0xff
+      carry >>= 8
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff)
+      carry >>= 8
+    }
+  }
+
+  // Preserve leading zeros
+  let leadingZeros = 0
+  for (let i = 0; i < input.length && input[i] === '1'; i++) {
+    leadingZeros++
+  }
+
+  const result = new Uint8Array(leadingZeros + bytes.length)
+  // Leading zeros are already 0 in the Uint8Array
+  for (let i = 0; i < bytes.length; i++) {
+    result[leadingZeros + i] = bytes[bytes.length - 1 - i]
+  }
+  return result
+}
+
+// --- VmClient ---
+
+const EPHEMERAL_KEY_PARAMS: EcKeyGenParams = {
+  name: 'ECDSA',
+  namedCurve: 'P-256',
+}
+
+const SIGN_ALGORITHM: EcdsaParams = {
+  name: 'ECDSA',
+  hash: { name: 'SHA-256' },
+}
+
+const PUBKEY_TTL_MS = 24 * 60 * 60 * 1000
+
+export class VmClient {
+  private readonly account: Account
+  private readonly nodeUrl: string
+  private readonly ephemeralKey: CryptoKeyPair
+  private cachedPubkeyHeader: string | null = null
+
+  private constructor(
+    account: Account,
+    nodeUrl: string,
+    ephemeralKey: CryptoKeyPair,
+  ) {
+    this.account = account
+    this.nodeUrl = nodeUrl
+    this.ephemeralKey = ephemeralKey
+  }
+
+  static async create(
+    account: Account,
+    nodeUrl: string,
+  ): Promise<VmClient> {
+    const normalized = nodeUrl.replace(/\/+\s*$/, '')
+    try {
+      new URL(normalized)
+    } catch {
+      throw new Error(`Invalid node URL: ${nodeUrl}`)
+    }
+
+    const ephemeralKey = await crypto.subtle.generateKey(
+      EPHEMERAL_KEY_PARAMS,
+      false,
+      ['sign', 'verify'],
+    )
+
+    return new VmClient(account, normalized, ephemeralKey)
+  }
+
+  private async buildPubkeyPayload(): Promise<string> {
+    const publicJwk = await crypto.subtle.exportKey(
+      'jwk',
+      this.ephemeralKey.publicKey,
+    )
+
+    const payload = {
+      pubkey: publicJwk,
+      alg: 'ECDSA',
+      domain: this.nodeUrl,
+      address: this.account.address,
+      chain: this.account.getChain(),
+      expires: new Date(
+        Date.now() + PUBKEY_TTL_MS,
+      ).toISOString(),
+    }
+
+    return JSON.stringify(payload)
+  }
+
+  private async buildPubkeySignatureHeader(
+    payloadJson: string,
+  ): Promise<string> {
+    const jsonBytes = utf8ToBytes(payloadJson)
+    const hexPayload = bytesToHex(jsonBytes)
+
+    const chain = this.account.getChain()
+    let verificationBuffer: Buffer
+
+    if (chain === Blockchain.SOL) {
+      verificationBuffer = Buffer.from(
+        utf8ToBytes(hexPayload),
+      )
+    } else {
+      verificationBuffer = Buffer.from(jsonBytes)
+    }
+
+    const signable: SignableMessage = {
+      time: Date.now() / 1000,
+      sender: this.account.address,
+      getVerificationBuffer: () => verificationBuffer,
+    }
+
+    let signature = await this.account.sign(signable)
+
+    if (chain === Blockchain.SOL) {
+      signature = this.convertSolSignatureToHex(signature)
+    }
+
+    const header = JSON.stringify({
+      sender: this.account.address,
+      payload: hexPayload,
+      signature,
+      content: { domain: this.nodeUrl },
+    })
+
+    return header
+  }
+
+  async ensurePubkeyHeader(): Promise<string> {
+    if (this.cachedPubkeyHeader) {
+      return this.cachedPubkeyHeader
+    }
+
+    const payloadJson = await this.buildPubkeyPayload()
+    const header = await this.buildPubkeySignatureHeader(
+      payloadJson,
+    )
+
+    this.cachedPubkeyHeader = header
+    return header
+  }
+
+  private async signControlPayload(
+    payload: string,
+  ): Promise<string> {
+    const payloadBytes = utf8ToBytes(payload)
+
+    const signatureBuffer = await crypto.subtle.sign(
+      SIGN_ALGORITHM,
+      this.ephemeralKey.privateKey,
+      payloadBytes,
+    )
+
+    return bytesToHex(new Uint8Array(signatureBuffer))
+  }
+
+  private convertSolSignatureToHex(
+    jsonSignature: string,
+  ): string {
+    const parsed = JSON.parse(jsonSignature)
+    const signatureStr: string =
+      parsed.signature ?? parsed
+    const decoded = base58Decode(signatureStr)
+    return '0x' + bytesToHex(decoded)
+  }
+
+  async buildHeaders(
+    vmId: string,
+    operation: VmOperation,
+    method: string = 'POST',
+  ): Promise<{ url: string; headers: Record<string, string> }> {
+    const pubkeyHeader = await this.ensurePubkeyHeader()
+
+    const path =
+      `/control/machine/${vmId}/${operation}`
+    const url = `${this.nodeUrl}${path}`
+
+    const operationPayload = JSON.stringify({
+      time: new Date().toISOString(),
+      method,
+      path,
+      domain: this.nodeUrl,
+    })
+
+    const hexPayload = bytesToHex(
+      utf8ToBytes(operationPayload),
+    )
+    const signature = await this.signControlPayload(
+      operationPayload,
+    )
+
+    const operationHeader = JSON.stringify({
+      sender: this.account.address,
+      payload: hexPayload,
+      signature,
+      content: { domain: this.nodeUrl },
+    })
+
+    return {
+      url,
+      headers: {
+        'X-SignedPubKey': pubkeyHeader,
+        'X-SignedOperation': operationHeader,
+      },
+    }
+  }
+
+  async performOperation(
+    vmId: string,
+    operation: VmOperation,
+    options?: {
+      method?: string
+      params?: Record<string, string>
+      jsonData?: unknown
+    },
+  ): Promise<VmOperationResult> {
+    const method = options?.method ?? 'POST'
+    const { url, headers } = await this.buildHeaders(
+      vmId,
+      operation,
+      method,
+    )
+
+    let fullUrl = url
+    if (options?.params) {
+      const searchParams = new URLSearchParams(
+        options.params,
+      )
+      fullUrl = `${url}?${searchParams.toString()}`
+    }
+
+    const fetchOptions: RequestInit = {
+      method,
+      headers: { ...headers },
+    }
+
+    if (options?.jsonData !== undefined) {
+      ;(
+        fetchOptions.headers as Record<string, string>
+      )['Content-Type'] = 'application/json'
+      fetchOptions.body = JSON.stringify(
+        options.jsonData,
+      )
+    }
+
+    const resp = await fetch(fullUrl, fetchOptions)
+    const responseText = await resp.text()
+
+    return {
+      status: resp.status,
+      response: responseText,
+    }
+  }
+
+  async startInstance(
+    vmId: string,
+  ): Promise<VmOperationResult> {
+    const url = `${this.nodeUrl}/control/allocation/notify`
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ instance: vmId }),
+    })
+    const responseText = await resp.text()
+    return { status: resp.status, response: responseText }
+  }
+
+  async stopInstance(
+    vmId: string,
+  ): Promise<VmOperationResult> {
+    return this.performOperation(
+      vmId,
+      VmOperation.Stop,
+    )
+  }
+
+  async rebootInstance(
+    vmId: string,
+  ): Promise<VmOperationResult> {
+    return this.performOperation(
+      vmId,
+      VmOperation.Reboot,
+    )
+  }
+
+  async eraseInstance(
+    vmId: string,
+  ): Promise<VmOperationResult> {
+    return this.performOperation(
+      vmId,
+      VmOperation.Erase,
+    )
+  }
+
+  async expireInstance(
+    vmId: string,
+  ): Promise<VmOperationResult> {
+    return this.performOperation(
+      vmId,
+      VmOperation.Expire,
+    )
+  }
+
+  async reinstallInstance(
+    vmId: string,
+    eraseVolumes?: boolean,
+  ): Promise<VmOperationResult> {
+    const params: Record<string, string> | undefined =
+      eraseVolumes !== undefined
+        ? { erase_volumes: String(eraseVolumes) }
+        : undefined
+
+    return this.performOperation(
+      vmId,
+      VmOperation.Reinstall,
+      { params },
+    )
+  }
+
+  async createBackup(
+    vmId: string,
+    options?: {
+      includeVolumes?: boolean
+      skipFsfreeze?: boolean
+    },
+  ): Promise<VmOperationResult> {
+    const params: Record<string, string> = {}
+    if (options?.includeVolumes !== undefined) {
+      params['include_volumes'] = String(
+        options.includeVolumes,
+      )
+    }
+    if (options?.skipFsfreeze !== undefined) {
+      params['skip_fsfreeze'] = String(
+        options.skipFsfreeze,
+      )
+    }
+
+    return this.performOperation(
+      vmId,
+      VmOperation.Backup,
+      {
+        params:
+          Object.keys(params).length > 0
+            ? params
+            : undefined,
+      },
+    )
+  }
+
+  async getBackup(
+    vmId: string,
+  ): Promise<VmOperationResult> {
+    return this.performOperation(
+      vmId,
+      VmOperation.Backup,
+      { method: 'GET' },
+    )
+  }
+
+  async deleteBackup(
+    vmId: string,
+    backupId: string,
+  ): Promise<VmOperationResult> {
+    if (!/^[a-zA-Z0-9_-]+$/.test(backupId)) {
+      throw new Error(
+        `Invalid backup ID: ${backupId}. ` +
+          'Must contain only alphanumeric characters, ' +
+          'underscores, and hyphens.',
+      )
+    }
+
+    const { url, headers } = await this.buildHeaders(
+      vmId,
+      VmOperation.Backup,
+      'DELETE',
+    )
+
+    const resp = await fetch(`${url}/${backupId}`, {
+      method: 'DELETE',
+      headers,
+    })
+    const responseText = await resp.text()
+    return { status: resp.status, response: responseText }
+  }
+
+  async restoreFromVolume(
+    vmId: string,
+    volumeRef: string,
+  ): Promise<VmOperationResult> {
+    return this.performOperation(
+      vmId,
+      VmOperation.Restore,
+      { jsonData: { volume_ref: volumeRef } },
+    )
+  }
+
+  async restoreFromFile(
+    vmId: string,
+    rootfsData: Blob,
+  ): Promise<VmOperationResult> {
+    const { url, headers } = await this.buildHeaders(
+      vmId,
+      VmOperation.Restore,
+      'POST',
+    )
+
+    const formData = new FormData()
+    formData.append('rootfs', rootfsData)
+
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: formData,
+    })
+    const responseText = await resp.text()
+    return { status: resp.status, response: responseText }
+  }
+
+  async getRestoreEndpoint(
+    vmId: string,
+  ): Promise<{ url: string; headers: Record<string, string> }> {
+    return this.buildHeaders(
+      vmId,
+      VmOperation.Restore,
+      'POST',
+    )
+  }
+}

--- a/packages/client/src/vmClient.ts
+++ b/packages/client/src/vmClient.ts
@@ -221,16 +221,11 @@ export class VmClient {
     return '0x' + bytesToHex(decoded)
   }
 
-  async buildHeaders(
-    vmId: string,
-    operation: VmOperation,
-    method: string = 'POST',
-  ): Promise<{ url: string; headers: Record<string, string> }> {
+  private async buildAuthHeaders(
+    path: string,
+    method: string,
+  ): Promise<Record<string, string>> {
     const pubkeyHeader = await this.ensurePubkeyHeader()
-
-    const path =
-      `/control/machine/${vmId}/${operation}`
-    const url = `${this.nodeUrl}${path}`
 
     const operationPayload = JSON.stringify({
       time: new Date().toISOString(),
@@ -254,12 +249,25 @@ export class VmClient {
     })
 
     return {
-      url,
-      headers: {
-        'X-SignedPubKey': pubkeyHeader,
-        'X-SignedOperation': operationHeader,
-      },
+      'X-SignedPubKey': pubkeyHeader,
+      'X-SignedOperation': operationHeader,
     }
+  }
+
+  async buildHeaders(
+    vmId: string,
+    operation: VmOperation,
+    method: string = 'POST',
+  ): Promise<{ url: string; headers: Record<string, string> }> {
+    const path =
+      `/control/machine/${vmId}/${operation}`
+    const url = `${this.nodeUrl}${path}`
+    const headers = await this.buildAuthHeaders(
+      path,
+      method,
+    )
+
+    return { url, headers }
   }
 
   async performOperation(
@@ -482,5 +490,125 @@ export class VmClient {
       VmOperation.Restore,
       'POST',
     )
+  }
+
+  getStreamLogsUrl(vmId: string): string {
+    const wsBase = this.nodeUrl.replace(
+      /^http/,
+      'ws',
+    )
+    return `${wsBase}/control/machine/${vmId}/stream_logs`
+  }
+
+  async *streamLogs(
+    vmId: string,
+    abort?: AbortSignal,
+  ): AsyncGenerator<LogEntry> {
+    const { headers } = await this.buildHeaders(
+      vmId,
+      VmOperation.StreamLogs,
+      'GET',
+    )
+
+    const wsUrl = this.getStreamLogsUrl(vmId)
+    const ws = new WebSocket(wsUrl)
+
+    const messageQueue: LogEntry[] = []
+    let resolve: (() => void) | null = null
+    let done = false
+    let error: Error | null = null
+
+    const cleanup = () => {
+      done = true
+      if (resolve) resolve()
+      if (
+        ws.readyState === WebSocket.OPEN ||
+        ws.readyState === WebSocket.CONNECTING
+      ) {
+        ws.close()
+      }
+    }
+
+    ws.onopen = () => {
+      const authMessage = JSON.stringify({
+        auth: {
+          'X-SignedPubKey': JSON.parse(
+            headers['X-SignedPubKey'],
+          ),
+          'X-SignedOperation': JSON.parse(
+            headers['X-SignedOperation'],
+          ),
+        },
+      })
+      ws.send(authMessage)
+    }
+
+    ws.onmessage = (event: MessageEvent) => {
+      const entry = JSON.parse(
+        String(event.data),
+      ) as LogEntry
+      messageQueue.push(entry)
+      if (resolve) resolve()
+    }
+
+    ws.onerror = () => {
+      error = new Error('WebSocket error')
+      cleanup()
+    }
+
+    ws.onclose = () => {
+      cleanup()
+    }
+
+    if (abort) {
+      abort.addEventListener(
+        'abort',
+        () => cleanup(),
+        { once: true },
+      )
+    }
+
+    try {
+      while (!done || messageQueue.length > 0) {
+        if (messageQueue.length > 0) {
+          yield messageQueue.shift()!
+          continue
+        }
+        if (done) break
+        await new Promise<void>((r) => {
+          resolve = r
+        })
+        resolve = null
+      }
+      if (error) throw error
+    } finally {
+      cleanup()
+    }
+  }
+
+  async reserveResources(
+    config: Record<string, unknown>,
+  ): Promise<VmOperationResult> {
+    const path = '/control/reserve_resources'
+    const url = `${this.nodeUrl}${path}`
+    const headers = await this.buildAuthHeaders(
+      path,
+      'POST',
+    )
+
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(config),
+    })
+    const responseText = await resp.text()
+
+    return {
+      status: resp.status,
+      response: responseText,
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,10 @@
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "importHelpers": true,
+    "baseUrl": ".",
+    "paths": {
+      "@aleph-sdk/*": ["packages/*/src"]
+    },
   },
   "exclude": [
     "**/node_modules",


### PR DESCRIPTION
## Summary

Adds a `VmClient` class to `@aleph-sdk/client` for managing CRN (Compute Resource Node) instances. Uses the **Web Crypto API** (`crypto.subtle`) instead of `node:crypto`, making it work in both **browsers and Node.js 15+**.

- Two-layer CRN authentication: `X-SignedPubKey` (ephemeral P-256 key signed by wallet, 24h TTL) + `X-SignedOperation` (per-request ES256 signature)
- Full VM lifecycle: start, stop, reboot, erase, expire, reinstall
- Backup/restore operations (depends on aleph-vm #874)
- WebSocket-based log streaming via async generator
- Resource reservation
- ETH and SOL wallet support with correct signing for each chain

### Supersedes PR #202

This PR is a complete rewrite of #202 (`feature/vm-client`), which used Node.js-only `node:crypto`. **PR #202 should be closed** when this merges — all functionality is covered here with browser compatibility added.

## Dependency PRs and Merge Order

These PRs form a chain and **must be merged in this order**:

| Order | PR | Repo | Description | Status |
|-------|-----|------|-------------|--------|
| 1 | [aleph-vm #874](https://github.com/aleph-im/aleph-vm/pull/874) | aleph-vm | Adds backup/restore CRN endpoints | Open |
| 2 | **This PR** | aleph-sdk-ts | Browser-compatible VmClient | This PR |
| 3 | *(after merge)* | aleph-sdk-ts | Version bump + npm publish of `@aleph-sdk/client` | Not yet created |
| 4 | *(after publish)* | front-aleph-cloud-page | Migrate `ExecutableManager` auth/VM control to use `VmClient` from SDK | Not yet created |

**Note:** This PR can be merged independently of aleph-vm #874 — the backup/restore methods will simply have no CRN endpoints to call until #874 lands. The front-end migration (PR #4) depends on this PR being published to npm first.

## Files Changed

- **`packages/client/src/vmClient.ts`** — VmClient class with all operations
- **`packages/client/src/utils/hex.ts`** — Browser-safe hex/UTF-8 encoding (replaces Buffer-based hex conversion)
- **`packages/client/__tests__/vmClient.test.ts`** — 27 tests covering auth headers, operations, SOL handling, backup/restore, streaming, resource reservation
- **`packages/client/__tests__/hex.test.ts`** — 14 tests including error path coverage
- **`packages/client/src/index.ts`** — Added VmClient export
- **`jest.config.js`** / **`tsconfig.json`** — Module resolution for monorepo test runs

## Test Plan

- [x] All 41 client tests pass (`npx jest packages/client/__tests__/`)
- [x] Full monorepo builds (16 packages)
- [x] Prettier formatting clean
- [ ] Manual testing against a live CRN (after aleph-vm #874 merges)