### PR TITLE
feat: cursor-based pagination for messages and posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ docs/
 
 .DS_Store
 .jest-cache/
+
+# Git worktrees
+.worktrees/

--- a/packages/client/src/httpClient.ts
+++ b/packages/client/src/httpClient.ts
@@ -2,14 +2,21 @@ import {
   AggregateMessageClient,
   AlephSocket,
   BaseMessageClient,
+  CursorMessagesResponse,
+  CursorPostsResponse,
   ForgetMessageClient,
   GetMessagesConfiguration,
+  GetMessagesCursorConfiguration,
   InstanceMessageClient,
+  MessageContent,
   MessageError,
   MessageType,
   PostGetConfiguration,
+  PostGetCursorConfiguration,
   PostMessageClient,
+  PostResponse,
   ProgramMessageClient,
+  PublishedMessage,
   StoreMessageClient,
 } from '@aleph-sdk/message'
 
@@ -114,6 +121,46 @@ export class AlephHttpClient {
    */
   async getMessageError(itemHash: string): Promise<MessageError | null> {
     return await this.messageClient.getError(itemHash)
+  }
+
+  /**
+   * Retrieves messages using cursor-based pagination. More efficient than page-based pagination for large result sets.
+   *
+   * @param config The configuration used to fetch messages (same filters as getMessages, minus `page`).
+   */
+  async getMessagesCursor(config: GetMessagesCursorConfiguration): Promise<CursorMessagesResponse> {
+    return await this.messageClient.getCursor(config)
+  }
+
+  /**
+   * Returns an async iterator over all messages matching the given filters.
+   * Handles cursor-based pagination automatically, yielding individual messages.
+   *
+   * @param config The filters used to query messages (same as getMessages, minus `page`).
+   */
+  getMessagesIterator(
+    config: Omit<GetMessagesCursorConfiguration, 'cursor'>,
+  ): AsyncGenerator<PublishedMessage<MessageContent>> {
+    return this.messageClient.getAsyncIterator(config)
+  }
+
+  /**
+   * Retrieves posts using cursor-based pagination. More efficient than page-based pagination for large result sets.
+   *
+   * @param config The configuration used to fetch posts (same filters as getPosts, minus `page`).
+   */
+  async getPostsCursor<T = any>(config: PostGetCursorConfiguration): Promise<CursorPostsResponse<T>> {
+    return await this.postClient.getCursor<T>(config)
+  }
+
+  /**
+   * Returns an async iterator over all posts matching the given filters.
+   * Handles cursor-based pagination automatically, yielding individual posts.
+   *
+   * @param config The filters used to query posts (same as getPosts, minus `page`).
+   */
+  getPostsIterator<T = any>(config: Omit<PostGetCursorConfiguration, 'cursor'>): AsyncGenerator<PostResponse<T>> {
+    return this.postClient.getAsyncIterator<T>(config)
   }
 
   /**

--- a/packages/message/__tests__/base/getCursor.test.ts
+++ b/packages/message/__tests__/base/getCursor.test.ts
@@ -1,0 +1,64 @@
+import { v4 as uuidv4 } from 'uuid'
+
+import { delay } from '../../../core/src'
+import * as ethereum from '../../../ethereum/src'
+import { BaseMessageClient, MessageContent, PostMessageClient, PublishedMessage } from '../../src'
+
+describe('Message cursor pagination', () => {
+  const messageClient = new BaseMessageClient()
+  const postClient = new PostMessageClient()
+
+  it('should return a cursor response with next_cursor field', async () => {
+    const res = await messageClient.getCursor({
+      channels: ['TEST'],
+      pagination: 5,
+    })
+
+    expect(Array.isArray(res.messages)).toBe(true)
+    expect(res.pagination_per_page).toBe(5)
+    expect(res).toHaveProperty('next_cursor')
+    expect('pagination_page' in res).toBe(false)
+    expect('pagination_total' in res).toBe(false)
+  })
+
+  it('should iterate over all messages from a sender across multiple pages', async () => {
+    const { account } = ethereum.newAccount()
+    const postType = uuidv4()
+    const totalPosts = 5
+
+    const published: string[] = []
+    for (let i = 0; i < totalPosts; i++) {
+      const res = await postClient.send({
+        channel: 'TEST',
+        account,
+        postType,
+        content: { index: i },
+        sync: true,
+      })
+      published.push(res.item_hash)
+    }
+
+    await delay(2000)
+
+    const collected: PublishedMessage<MessageContent>[] = []
+    for await (const message of messageClient.getAsyncIterator({
+      addresses: [account.address],
+      pagination: 2,
+    })) {
+      collected.push(message)
+    }
+
+    expect(collected.length).toBe(totalPosts)
+    const collectedHashes = collected.map((m) => m.item_hash).sort()
+    expect(collectedHashes).toStrictEqual(published.sort())
+  })
+
+  it('should cap pagination at 200', async () => {
+    const res = await messageClient.getCursor({
+      channels: ['TEST'],
+      pagination: 500,
+    })
+
+    expect(res.pagination_per_page).toBeLessThanOrEqual(200)
+  })
+})

--- a/packages/message/__tests__/post/getCursor.test.ts
+++ b/packages/message/__tests__/post/getCursor.test.ts
@@ -1,0 +1,63 @@
+import { v4 as uuidv4 } from 'uuid'
+
+import { delay } from '../../../core/src'
+import * as ethereum from '../../../ethereum/src'
+import { PostMessageClient, PostResponse } from '../../src'
+
+describe('Post cursor pagination', () => {
+  const post = new PostMessageClient()
+
+  it('should return a cursor response with next_cursor field', async () => {
+    const res = await post.getCursor({
+      channels: ['TEST'],
+      pagination: 5,
+    })
+
+    expect(Array.isArray(res.posts)).toBe(true)
+    expect(res.pagination_per_page).toBe(5)
+    expect(res).toHaveProperty('next_cursor')
+    expect('pagination_page' in res).toBe(false)
+    expect('pagination_total' in res).toBe(false)
+  })
+
+  it('should iterate over all posts across multiple pages until next_cursor is null', async () => {
+    const { account } = ethereum.newAccount()
+    const postType = uuidv4()
+    const totalPosts = 5
+
+    const published: string[] = []
+    for (let i = 0; i < totalPosts; i++) {
+      const res = await post.send({
+        channel: 'TEST',
+        account,
+        postType,
+        content: { index: i },
+        sync: true,
+      })
+      published.push(res.item_hash)
+    }
+
+    await delay(2000)
+
+    const collected: PostResponse<{ index: number }>[] = []
+    for await (const item of post.getAsyncIterator<{ index: number }>({
+      types: postType,
+      pagination: 2,
+    })) {
+      collected.push(item)
+    }
+
+    expect(collected.length).toBe(totalPosts)
+    const collectedHashes = collected.map((p) => p.item_hash).sort()
+    expect(collectedHashes).toStrictEqual(published.sort())
+  })
+
+  it('should cap pagination at 200', async () => {
+    const res = await post.getCursor({
+      channels: ['TEST'],
+      pagination: 500,
+    })
+
+    expect(res.pagination_per_page).toBeLessThanOrEqual(200)
+  })
+})

--- a/packages/message/src/base/impl.ts
+++ b/packages/message/src/base/impl.ts
@@ -2,15 +2,18 @@ import { DEFAULT_API_V2, DEFAULT_API_WS_V2, getSocketPath, stripTrailingSlash } 
 import axios, { type AxiosResponse } from 'axios'
 
 import {
+  CursorMessagesResponse,
   GetMessageConfiguration,
   GetMessageParams,
   GetMessagesConfiguration,
+  GetMessagesCursorConfiguration,
+  GetMessagesCursorParams,
   GetMessagesParams,
   MessageError,
   MessageResponse,
   MessagesQueryResponse,
 } from './types'
-import { MessageStatus, MessageType, MessageTypeMap, PublishedMessage } from '../types'
+import { MessageContent, MessageStatus, MessageType, MessageTypeMap, PublishedMessage } from '../types'
 import { AlephSocket, getMessagesSocket, GetMessagesSocketConfiguration } from './websocket'
 import { ForgottenMessageError, MessageNotFoundError, QueryError } from '../types/errors'
 import { toQueryParam } from '../utils'
@@ -145,6 +148,75 @@ export class BaseMessageClient {
     })) as AxiosResponse<MessagesQueryResponse>
 
     return response.data
+  }
+
+  /**
+   * Retrieves Messages using cursor-based pagination.
+   * Pass an empty cursor (or omit it) to start from the beginning.
+   *
+   * @param configuration The message params to make the query.
+   */
+  async getCursor({
+    pagination = 200,
+    cursor = '',
+    addresses,
+    channels,
+    chains,
+    refs,
+    tags,
+    contentTypes,
+    contentKeys,
+    hashes,
+    messageTypes,
+    paymentTypes,
+    startDate,
+    endDate,
+  }: GetMessagesCursorConfiguration): Promise<CursorMessagesResponse> {
+    const params: GetMessagesCursorParams = {
+      pagination: Math.min(pagination ?? 200, 200),
+      cursor,
+      addresses: toQueryParam(addresses),
+      channels: toQueryParam(channels),
+      chains: toQueryParam(chains),
+      refs: toQueryParam(refs),
+      tags: toQueryParam(tags),
+      contentTypes: toQueryParam(contentTypes),
+      contentKeys: toQueryParam(contentKeys),
+      hashes: toQueryParam(hashes),
+      msgTypes: toQueryParam(messageTypes),
+      paymentTypes: toQueryParam(paymentTypes),
+      startDate: startDate ? startDate.valueOf() / 1000 : undefined,
+      endDate: endDate ? endDate.valueOf() / 1000 : undefined,
+    }
+
+    const response = (await axios.get<CursorMessagesResponse>(`${this.apiServer}/api/v0/messages.json`, {
+      params,
+      socketPath: getSocketPath(),
+    })) as AxiosResponse<CursorMessagesResponse>
+
+    return response.data
+  }
+
+  /**
+   * Returns an async iterator over all messages matching the given filters.
+   * Handles cursor-based pagination automatically.
+   *
+   * @param configuration The message filters (same as getAll, minus `page`).
+   */
+  async *getAsyncIterator(
+    configuration: Omit<GetMessagesCursorConfiguration, 'cursor'>,
+  ): AsyncGenerator<PublishedMessage<MessageContent>> {
+    let cursor: string = ''
+    while (true) {
+      const response = await this.getCursor({ ...configuration, cursor })
+      for (const message of response.messages) {
+        yield message
+      }
+      if (response.next_cursor === null) {
+        break
+      }
+      cursor = response.next_cursor
+    }
   }
 
   async getMessagesSocket(params: Omit<GetMessagesSocketConfiguration, 'apiServer'>): Promise<AlephSocket> {

--- a/packages/message/src/base/impl.ts
+++ b/packages/message/src/base/impl.ts
@@ -173,7 +173,7 @@ export class BaseMessageClient {
     endDate,
   }: GetMessagesCursorConfiguration): Promise<CursorMessagesResponse> {
     const params: GetMessagesCursorParams = {
-      pagination: Math.min(pagination ?? 200, 200),
+      pagination: Math.min(pagination, 200),
       cursor,
       addresses: toQueryParam(addresses),
       channels: toQueryParam(channels),

--- a/packages/message/src/base/types.ts
+++ b/packages/message/src/base/types.ts
@@ -73,4 +73,20 @@ export type GetMessagesParams = {
   endDate?: number
 }
 
+// --------- CURSOR PAGINATION ------------
+
+export type CursorMessagesResponse = {
+  messages: PublishedMessage<MessageContent>[]
+  pagination_per_page: number
+  next_cursor: string | null
+}
+
+export type GetMessagesCursorConfiguration = Omit<GetMessagesConfiguration, 'page'> & {
+  cursor?: string
+}
+
+export type GetMessagesCursorParams = Omit<GetMessagesParams, 'page'> & {
+  cursor: string
+}
+
 export type MessageError = { error_code: string; details: string }

--- a/packages/message/src/post/impl.ts
+++ b/packages/message/src/post/impl.ts
@@ -93,7 +93,7 @@ export class PostMessageClient {
   }: PostGetCursorConfiguration): Promise<CursorPostsResponse<T>> {
     const params: PostCursorQueryParams = {
       types: toQueryParam(types),
-      pagination: Math.min(pagination ?? 200, 200),
+      pagination: Math.min(pagination, 200),
       cursor,
       refs: toQueryParam(refs),
       addresses: toQueryParam(addresses),

--- a/packages/message/src/post/impl.ts
+++ b/packages/message/src/post/impl.ts
@@ -2,8 +2,11 @@ import { DEFAULT_API_V2, getSocketPath, stripTrailingSlash } from '@aleph-sdk/co
 import axios, { type AxiosResponse } from 'axios'
 
 import {
+  CursorPostsResponse,
   PostContent,
+  PostCursorQueryParams,
   PostGetConfiguration,
+  PostGetCursorConfiguration,
   PostPublishConfiguration,
   PostQueryParams,
   PostQueryResponse,
@@ -72,6 +75,58 @@ export class PostMessageClient {
       socketPath: getSocketPath(),
     })) as AxiosResponse<PostQueryResponse<T>>
     return response.data
+  }
+
+  /**
+   * Queries the Aleph network for post messages using cursor-based pagination.
+   * Pass an empty cursor (or omit it) to start from the beginning.
+   */
+  async getCursor<T = any>({
+    types,
+    pagination = 200,
+    cursor = '',
+    channels,
+    refs,
+    addresses,
+    tags,
+    hashes,
+  }: PostGetCursorConfiguration): Promise<CursorPostsResponse<T>> {
+    const params: PostCursorQueryParams = {
+      types: toQueryParam(types),
+      pagination: Math.min(pagination ?? 200, 200),
+      cursor,
+      refs: toQueryParam(refs),
+      addresses: toQueryParam(addresses),
+      tags: toQueryParam(tags),
+      hashes: toQueryParam(hashes),
+      channels: toQueryParam(channels),
+    }
+
+    const response = (await axios.get<CursorPostsResponse<T>>(`${this.apiServer}/api/v0/posts.json`, {
+      params,
+      socketPath: getSocketPath(),
+    })) as AxiosResponse<CursorPostsResponse<T>>
+    return response.data
+  }
+
+  /**
+   * Returns an async iterator over all posts matching the given filters.
+   * Handles cursor-based pagination automatically.
+   */
+  async *getAsyncIterator<T = any>(
+    configuration: Omit<PostGetCursorConfiguration, 'cursor'>,
+  ): AsyncGenerator<PostResponse<T>> {
+    let cursor: string = ''
+    while (true) {
+      const response = await this.getCursor<T>({ ...configuration, cursor })
+      for (const post of response.posts) {
+        yield post
+      }
+      if (response.next_cursor === null) {
+        break
+      }
+      cursor = response.next_cursor
+    }
   }
 
   /**

--- a/packages/message/src/post/types.ts
+++ b/packages/message/src/post/types.ts
@@ -63,6 +63,20 @@ export type PostQueryResponse<T> = {
   pagination_item: string
 }
 
+export type CursorPostsResponse<T> = {
+  posts: PostResponse<T>[]
+  pagination_per_page: number
+  next_cursor: string | null
+}
+
+export type PostGetCursorConfiguration = Omit<PostGetConfiguration, 'page'> & {
+  cursor?: string
+}
+
+export type PostCursorQueryParams = Omit<PostQueryParams, 'page'> & {
+  cursor: string
+}
+
 // ------- PUBLISH -------
 
 export type PostPublishConfiguration<T> = {


### PR DESCRIPTION
## Summary

- Add `getCursor()` and `getAsyncIterator()` methods to `BaseMessageClient` and `PostMessageClient`
- Add facade methods on `AlephHttpClient`: `getMessagesCursor()`, `getMessagesIterator()`, `getPostsCursor()`, `getPostsIterator()`
- New cursor response types (`CursorMessagesResponse`, `CursorPostsResponse`) with `next_cursor` instead of `pagination_page`/`pagination_total`
- Page size defaults to 200, capped at 200 client-side
- Async iterators handle the full cursor loop, yielding individual items until `next_cursor` is null

Matches the cursor-based pagination added to the Python and Rust SDKs. See `pyaleph/docs/cursor-pagination-sdk-spec.md` for the server-side spec.

## Test plan

- [ ] Verify `getCursor()` returns correct response shape with `next_cursor` field
- [ ] Verify `getAsyncIterator()` yields all items across multiple pages
- [ ] Verify pagination is capped at 200
- [ ] Verify empty cursor starts from the beginning
- [ ] Test against a live CCN endpoint