### PR TITLE
Feat/external signer account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ docs/
 .gitsigners
 
 .DS_Store
+.jest-cache/

--- a/packages/ethereum/src/account.ts
+++ b/packages/ethereum/src/account.ts
@@ -1,6 +1,6 @@
 import { SignableMessage } from '@aleph-sdk/account'
 import { Blockchain } from '@aleph-sdk/core'
-import { ChainMetadata, ChangeRpcParam, EVMAccount, hexToDec, JsonRPCWallet, RpcId } from '@aleph-sdk/evm'
+import { ChainMetadata, ChangeRpcParam, EVMAccount, ExternalSignerWallet, hexToDec, JsonRPCWallet, RpcId } from '@aleph-sdk/evm'
 import * as bip39 from 'bip39'
 import { providers, Wallet } from 'ethers'
 
@@ -9,11 +9,15 @@ import { providers, Wallet } from 'ethers'
  * It is used to represent an ethereum account when publishing a message on the Aleph network.
  */
 export class ETHAccount extends EVMAccount {
-  public override readonly wallet: Wallet | JsonRPCWallet
+  public override readonly wallet: Wallet | JsonRPCWallet | ExternalSignerWallet
 
-  public constructor(wallet: Wallet | JsonRPCWallet, address: string, publicKey?: string, rpcId?: number) {
+  public constructor(wallet: Wallet | JsonRPCWallet | ExternalSignerWallet, address: string, publicKey?: string, rpcId?: number) {
     super(address, publicKey)
     this.selectedRpcId = rpcId || RpcId.ETH
+    if (wallet instanceof ExternalSignerWallet) {
+      this.wallet = wallet
+      return
+    }
     if (wallet instanceof Wallet && !wallet.provider) {
       const network = ChainMetadata[rpcId || this.selectedRpcId]
       const provider = new providers.JsonRpcProvider(network.rpcUrls.at(0), {
@@ -41,13 +45,15 @@ export class ETHAccount extends EVMAccount {
   override async askPubKey(): Promise<void> {
     if (this.publicKey) return
     if (!this.wallet) throw Error('PublicKey Error: No providers are setup')
-
+    if (this.wallet instanceof ExternalSignerWallet) {
+      // ECIES encryption not yet supported for external signers
+      throw new Error('PublicKey not available for ExternalSignerWallet accounts')
+    }
     if (this.wallet instanceof Wallet) {
       this.publicKey = this.wallet.publicKey
       return
     }
     this.publicKey = await this.wallet.getPublicKey()
-    return
   }
 
   /**
@@ -122,4 +128,38 @@ export async function getAccountFromProvider(
   if (jrw.address)
     return new ETHAccount(jrw, jrw.address, undefined, typeof requestedRpc === 'number' ? requestedRpc : undefined)
   throw new Error('Insufficient permissions')
+}
+
+/**
+ * Creates an ETHAccount backed by any async signing function.
+ *
+ * Intended for embedded or smart-wallet signers (e.g. Privy) that are not
+ * backed by a standard Web3 provider. The caller supplies:
+ *   - address      — the signer's on-chain address (use the smart wallet address)
+ *   - provider     — a JSON-RPC provider for balance and chain queries
+ *   - signMessage  — the signing function, e.g.:
+ *                    (msg) => smartWalletClient.signMessage({ message: msg.toString() })
+ *   - requestedRpc — optional RPC preset (default: ETH mainnet)
+ *
+ * @example
+ * const account = getAccountFromExternalSigner(
+ *   smartWalletAddress,
+ *   new providers.JsonRpcProvider(rpcUrl),
+ *   (msg) => smartWalletClient.signMessage({ message: msg.toString() }),
+ *   RpcId.ETH,
+ * )
+ */
+export function getAccountFromExternalSigner(
+  address: string,
+  provider: providers.JsonRpcProvider,
+  signMessage: (message: Buffer | string) => Promise<string>,
+  requestedRpc: ChangeRpcParam = RpcId.ETH,
+): ETHAccount {
+  const wallet = new ExternalSignerWallet(address, provider, signMessage)
+  return new ETHAccount(
+    wallet,
+    address,
+    undefined,
+    typeof requestedRpc === 'number' ? requestedRpc : undefined,
+  )
 }

--- a/packages/ethereum/src/account.ts
+++ b/packages/ethereum/src/account.ts
@@ -1,6 +1,14 @@
 import { SignableMessage } from '@aleph-sdk/account'
 import { Blockchain } from '@aleph-sdk/core'
-import { ChainMetadata, ChangeRpcParam, EVMAccount, ExternalSignerWallet, hexToDec, JsonRPCWallet, RpcId } from '@aleph-sdk/evm'
+import {
+  ChainMetadata,
+  ChangeRpcParam,
+  EVMAccount,
+  ExternalSignerWallet,
+  hexToDec,
+  JsonRPCWallet,
+  RpcId,
+} from '@aleph-sdk/evm'
 import * as bip39 from 'bip39'
 import { providers, Wallet } from 'ethers'
 
@@ -11,7 +19,12 @@ import { providers, Wallet } from 'ethers'
 export class ETHAccount extends EVMAccount {
   public override readonly wallet: Wallet | JsonRPCWallet | ExternalSignerWallet
 
-  public constructor(wallet: Wallet | JsonRPCWallet | ExternalSignerWallet, address: string, publicKey?: string, rpcId?: number) {
+  public constructor(
+    wallet: Wallet | JsonRPCWallet | ExternalSignerWallet,
+    address: string,
+    publicKey?: string,
+    rpcId?: number,
+  ) {
     super(address, publicKey)
     this.selectedRpcId = rpcId || RpcId.ETH
     if (wallet instanceof ExternalSignerWallet) {
@@ -156,10 +169,5 @@ export function getAccountFromExternalSigner(
   requestedRpc: ChangeRpcParam = RpcId.ETH,
 ): ETHAccount {
   const wallet = new ExternalSignerWallet(address, provider, signMessage)
-  return new ETHAccount(
-    wallet,
-    address,
-    undefined,
-    typeof requestedRpc === 'number' ? requestedRpc : undefined,
-  )
+  return new ETHAccount(wallet, address, undefined, typeof requestedRpc === 'number' ? requestedRpc : undefined)
 }

--- a/packages/evm/src/account.ts
+++ b/packages/evm/src/account.ts
@@ -2,16 +2,19 @@ import { ECIESAccount } from '@aleph-sdk/account'
 import { Decimal } from 'decimal.js'
 import { Contract, Wallet } from 'ethers'
 
-import { ChainData, ChainMetadata, decToHex, JsonRPCWallet, RpcId, RpcType } from './provider'
+import { ChainData, ChainMetadata, decToHex, ExternalSignerWallet, JsonRPCWallet, RpcId, RpcType } from './provider'
 import { erc20Abi, weiToAleph } from './utils'
 
 export abstract class EVMAccount extends ECIESAccount {
-  public wallet?: Wallet | JsonRPCWallet
+  public wallet?: Wallet | JsonRPCWallet | ExternalSignerWallet
   public selectedRpcId?: RpcId
 
   public async getChainId(): Promise<number> {
     if (this.wallet instanceof JsonRPCWallet) {
       return this.wallet.provider.network.chainId
+    }
+    if (this.wallet instanceof ExternalSignerWallet) {
+      return (await this.wallet.provider.getNetwork()).chainId
     }
     if (this.wallet instanceof Wallet) {
       return (await this.wallet.provider.getNetwork()).chainId
@@ -28,6 +31,9 @@ export abstract class EVMAccount extends ECIESAccount {
 
   public getRpcUrl(): string {
     if (this.wallet instanceof JsonRPCWallet) {
+      return this.wallet.provider.connection.url
+    }
+    if (this.wallet instanceof ExternalSignerWallet) {
       return this.wallet.provider.connection.url
     }
     if (this.wallet instanceof Wallet) {

--- a/packages/evm/src/provider/external.ts
+++ b/packages/evm/src/provider/external.ts
@@ -45,7 +45,7 @@ export class ExternalSignerWallet extends BaseProviderWallet {
     // Throw until the SDK re-introduces encryption support.
     throw new Error(
       'ExternalSignerWallet: getPublicKey is not supported. ' +
-      'ECIES encryption is not yet available for external signer accounts.',
+        'ECIES encryption is not yet available for external signer accounts.',
     )
   }
 

--- a/packages/evm/src/provider/external.ts
+++ b/packages/evm/src/provider/external.ts
@@ -1,0 +1,55 @@
+import { BaseProviderWallet } from '@aleph-sdk/account'
+import { providers } from 'ethers'
+
+/**
+ * Wraps any async sign function as a BaseProviderWallet so it can be used
+ * with ETHAccount and EVMAccount. Intended for embedded/smart-wallet signers
+ * (e.g. Privy) that are not backed by a standard ethers.js wallet or Web3 provider.
+ *
+ * The caller must supply:
+ * - address       — the account's on-chain address (SA for smart wallets)
+ * - provider      — a standard JSON-RPC provider for balance/chain queries
+ * - signMessage   — the signing function (e.g. smartWalletClient.signMessage)
+ */
+export class ExternalSignerWallet extends BaseProviderWallet {
+  public readonly address: string
+  public override readonly provider: providers.JsonRpcProvider
+  private readonly _signMessage: (message: Buffer | string) => Promise<string>
+
+  constructor(
+    address: string,
+    provider: providers.JsonRpcProvider,
+    signMessage: (message: Buffer | string) => Promise<string>,
+  ) {
+    super()
+    this.address = address
+    this.provider = provider
+    this._signMessage = signMessage
+  }
+
+  async connect(): Promise<void> {
+    // No-op: address is known at construction time
+  }
+
+  async signMessage(data: Buffer | string): Promise<string> {
+    return this._signMessage(data)
+  }
+
+  async getCurrentChainId(): Promise<number> {
+    const network = await this.provider.getNetwork()
+    return network.chainId
+  }
+
+  async getPublicKey(): Promise<string> {
+    // ECIES encryption was removed in v1.0.0 and is not yet re-enabled.
+    // Throw until the SDK re-introduces encryption support.
+    throw new Error(
+      'ExternalSignerWallet: getPublicKey is not supported. ' +
+      'ECIES encryption is not yet available for external signer accounts.',
+    )
+  }
+
+  isMetamask(): boolean {
+    return false
+  }
+}

--- a/packages/evm/src/provider/index.ts
+++ b/packages/evm/src/provider/index.ts
@@ -1,2 +1,3 @@
 export * from './rpc'
 export * from './mock'
+export * from './external'


### PR DESCRIPTION
## Summary

  - Add `ExternalSignerWallet` to `@aleph-sdk/evm` — wraps any async sign function as a `BaseProviderWallet`, enabling embedded/smart-wallet signers (e.g. Privy) without coupling the SDK to any specific provider
  - Extend `EVMAccount` and `ETHAccount` wallet unions to accept `ExternalSignerWallet`; handle it in `getChainId()`, `getRpcUrl()`, constructor, and `askPubKey()`
  - Add `getAccountFromExternalSigner(address, provider, signMessage, rpcId?)` factory to `@aleph-sdk/ethereum` as the public entry point

  ## Notes

  - Zero breaking changes — all existing factory functions untouched
  - `getPublicKey()` / `askPubKey()` throw a clear error (ECIES encryption not yet re-enabled for external signers)
  - Caller supplies a `JsonRpcProvider` for chain/balance queries; signing is fully delegated to the provided function

  ## Test plan

  - [ ] All existing tests pass (`npm test` — 76/76)
  - [ ] Manual: instantiate via `getAccountFromExternalSigner` with a mock sign function and verify signing works end-to-end
  - [ ] Manual: verify `getChainId()` and `getRpcUrl()` return correct values from the supplied provider