### PR TITLE
feat: default instance payment type to credit

### DIFF
--- a/packages/message/__tests__/instance/publish.test.ts
+++ b/packages/message/__tests__/instance/publish.test.ts
@@ -1,7 +1,9 @@
 import axios from 'axios'
 
+import { Blockchain } from '@aleph-sdk/core'
+
 import * as ethereum from '../../../ethereum/src'
-import { InstanceMessageClient, MAXIMUM_DISK_SIZE } from '../../src'
+import { InstanceMessageClient, MAXIMUM_DISK_SIZE, PaymentType } from '../../src'
 
 jest.mock('axios')
 const mockedAxios = axios as jest.Mocked<typeof axios>
@@ -79,5 +81,19 @@ describe('Test the instance message', () => {
     })
 
     expect(res.content.rootfs.size_mib).toBe(MAXIMUM_DISK_SIZE)
+  })
+
+  it('defaults payment to credit on ETH when none is provided', async () => {
+    const { account } = ethereum.newAccount()
+    mockedAxios.post.mockResolvedValueOnce({ status: 200, data: {} })
+
+    const res = await instance.send({
+      account: account,
+      channel: 'TEST',
+    })
+
+    expect(res.content.payment).toBeDefined()
+    expect(res.content.payment?.type).toBe(PaymentType.credit)
+    expect(res.content.payment?.chain).toBe(Blockchain.ETH)
   })
 })

--- a/packages/message/__tests__/instance/publish.test.ts
+++ b/packages/message/__tests__/instance/publish.test.ts
@@ -1,6 +1,5 @@
-import axios from 'axios'
-
 import { Blockchain } from '@aleph-sdk/core'
+import axios from 'axios'
 
 import * as ethereum from '../../../ethereum/src'
 import { InstanceMessageClient, MAXIMUM_DISK_SIZE, PaymentType } from '../../src'

--- a/packages/message/src/instance/impl.ts
+++ b/packages/message/src/instance/impl.ts
@@ -73,7 +73,7 @@ export class InstanceMessageClient extends DefaultMessageClient<
     storageEngine = ItemType.ipfs,
     payment = {
       chain: Blockchain.ETH,
-      type: PaymentType.hold,
+      type: PaymentType.credit,
     },
   }: InstancePublishConfiguration): Promise<InstanceContent> {
     const timestamp = Date.now() / 1000

--- a/packages/message/src/types/execution.ts
+++ b/packages/message/src/types/execution.ts
@@ -116,7 +116,7 @@ export type HostRequirements = {
  *
  * chain: Blockchain to use
  * receiver: Receiver address, should be usually the (streaming) reward address of the targeted node
- * type: Payment type (hold, stream)
+ * type: Payment type (hold, superfluid, credit)
  */
 export type Payment = {
   chain: Blockchain


### PR DESCRIPTION
## Summary
- Change `InstanceMessageClient` default `payment.type` from `hold` to `credit` (chain stays `ETH`).
- Update `Payment` docstring in `execution.ts` to list all supported types (`hold, superfluid, credit`).
- Add instance test covering the new default.

**Breaking change:** callers who relied on the implicit `hold` default for instance messages will now emit `credit` messages. Pass `payment: { type: PaymentType.hold, chain: ... }` explicitly to preserve prior behavior.

Note: `ProgramMessageClient` still defaults to `hold` — out of scope here.

## Test plan
- [x] New test `defaults payment to credit on ETH when none is provided` passes
- [x] Full `packages/message` suite: 11/11 suites, 27 passed, 8 pre-existing skips, no regressions
- [ ] Confirm backend CCN accepts credit-paid instance messages end-to-end