### PR TITLE
fix(message): lazy-load ws to unblock browser bundlers

### DIFF
--- a/packages/message/src/base/impl.ts
+++ b/packages/message/src/base/impl.ts
@@ -147,7 +147,7 @@ export class BaseMessageClient {
     return response.data
   }
 
-  getMessagesSocket(params: Omit<GetMessagesSocketConfiguration, 'apiServer'>): AlephSocket {
+  async getMessagesSocket(params: Omit<GetMessagesSocketConfiguration, 'apiServer'>): Promise<AlephSocket> {
     return getMessagesSocket({
       ...params,
       apiServer: this.wsServer,

--- a/packages/message/src/base/websocket/alephNodeWebSocket.ts
+++ b/packages/message/src/base/websocket/alephNodeWebSocket.ts
@@ -1,6 +1,10 @@
-import WebSocket from 'ws'
+// Type-only import: erased at emit, so browser bundlers walking the import
+// graph never see a static reference to the Node-only `ws` package.
+import type WebSocket from 'ws'
 
 import { GetMessagesSocketParams, SocketResponse } from './types'
+
+export type WebSocketCtor = typeof WebSocket
 
 /**
  * This class is used to manipulate Node Web Socket to list Aleph Messages
@@ -11,7 +15,7 @@ export class AlephNodeWebSocket {
 
   private isOpen: boolean
 
-  constructor(queryParam: GetMessagesSocketParams, apiServer: string) {
+  constructor(queryParam: GetMessagesSocketParams, apiServer: string, WebSocketCtor: WebSocketCtor) {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this
     this.isOpen = false
@@ -22,7 +26,7 @@ export class AlephNodeWebSocket {
       if (value) queryParamString = queryParamString + `&${key}=${value}`
     })
     if (queryParamString) queryParamString = queryParamString.substring(1)
-    this.socket = new WebSocket(`${apiServer}/api/ws0/messages?${queryParamString}`)
+    this.socket = new WebSocketCtor(`${apiServer}/api/ws0/messages?${queryParamString}`)
 
     // ON OPEN SOCKET
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/message/src/base/websocket/getMessagesSocket.ts
+++ b/packages/message/src/base/websocket/getMessagesSocket.ts
@@ -8,9 +8,13 @@ import { AlephSocket, GetMessagesSocketConfiguration, GetMessagesSocketParams } 
  * Retrieves all incoming messages by opening a WebSocket.
  * Messages can be filtered with the params.
  *
+ * In Node, the `ws` package is loaded lazily via a dynamic import so that
+ * browser bundlers walking this module's static import graph never pull in
+ * Node-only dependencies.
+ *
  * @param configuration The message params to make the query.
  */
-export function getMessagesSocket({
+export async function getMessagesSocket({
   addresses = [],
   channels = [],
   chains = [],
@@ -25,7 +29,7 @@ export function getMessagesSocket({
   endDate,
   history,
   apiServer = DEFAULT_API_WS_V2,
-}: GetMessagesSocketConfiguration): AlephSocket {
+}: GetMessagesSocketConfiguration): Promise<AlephSocket> {
   const params: GetMessagesSocketParams = {
     addresses: addresses.join(',') || undefined,
     channels: channels.join(',') || undefined,
@@ -42,6 +46,9 @@ export function getMessagesSocket({
     history: history || undefined,
   }
 
-  if (isNode()) return new AlephNodeWebSocket(params, apiServer)
-  else return new AlephWebSocket(params, apiServer)
+  if (isNode()) {
+    const { default: WebSocket } = await import('ws')
+    return new AlephNodeWebSocket(params, apiServer, WebSocket)
+  }
+  return new AlephWebSocket(params, apiServer)
 }


### PR DESCRIPTION
## Summary

- `AlephNodeWebSocket` had a top-level `import WebSocket from 'ws'` that leaked into `@aleph-sdk/message`'s public barrel, dragging `ws` (and its Node-only transitive deps: `net`, `tls`, `zlib`, `bufferutil`, `utf-8-validate`) into browser bundle graphs even though the class is never instantiated in a browser.
- Switched to `import type WebSocket from 'ws'` (erased at emit) plus a lazy `await import('ws')` in `getMessagesSocket`'s `isNode()` branch. The `ws` constructor is now passed into `AlephNodeWebSocket` at construction time.
- `BaseMessageClient.getMessagesSocket` becomes `async`, returning `Promise<AlephSocket>`. `AlephHttpClient.watchMessages` was already declared `async … Promise<AlephSocket>`, so the top-level API is source-transparent.

## Breaking changes

- `getMessagesSocket(...)` returns `Promise<AlephSocket>` instead of `AlephSocket`. Callers must `await` it.
- `new AlephNodeWebSocket(params, apiServer)` now requires a third argument (the `ws` constructor). Direct consumers — rare; the canonical path is `getMessagesSocket` / `watchMessages` — must now `const { default: WS } = await import('ws')` and pass `WS` themselves.

Warrants a minor-version bump of `@aleph-sdk/message`.

## Test plan

- [x] `@aleph-sdk/message` builds (rollup, CJS + ESM + dts).
- [x] `@aleph-sdk/client` builds (catches downstream type breaks).
- [x] Grep of `dist/`: only **one** dynamic `import("ws")` per bundle, **zero** static `from "ws"` lines.
- [x] `jest ./packages/message ./packages/client`: identical to baseline on `main` (15 pre-existing wallet-integration failures, none touching websocket code; sockets have no test coverage).
- [x] `eslint` clean on changed files.
- [ ] Manual smoke: bundle a trivial browser app that imports from `@aleph-sdk/client` with no bundler shims and confirm `ws` is absent from the output.