### PR TITLE
ci: upload coverage to Codecov

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,3 +29,10 @@ jobs:
         run: npm run test
         env:
           CI: true
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,7 @@ export default {
     ...tsJestTransformCfg,
   },
   testPathIgnorePatterns: ['<rootDir>/cypress/'],
-  coverageReporters: ['text-summary', 'html'],
+  coverageReporters: ['text-summary', 'html', 'lcov'],
   transformIgnorePatterns: ['/node_modules/'],
   // Limit the number of workers to prevent CPU overload
   maxWorkers: '50%',


### PR DESCRIPTION
## Summary

- Adds `lcov` to Jest's `coverageReporters` so each test run writes `coverage/lcov.info`.
- Adds a `codecov/codecov-action@v5` step to `.github/workflows/test.yaml` that uploads the report after `npm run test`.

Today coverage is generated locally on every test run (`npm run test` already passes `--coverage`) but the report is discarded — there's no per-PR view, no history, no enforcement. This wires the existing report into Codecov so it's actually visible.

`fail_ci_if_error` is set to `false` so a Codecov outage doesn't break the test suite. We can flip it to `true` once the upload proves reliable.

## Required before this works

- [ ] Activate `aleph-im/aleph-sdk-ts` on codecov.io
- [ ] Add `CODECOV_TOKEN` as a repo secret (Settings → Secrets and variables → Actions). v5 of the action requires it even for public repos.

## Test plan

- [ ] CI runs the workflow on this PR
- [ ] The "Upload coverage to Codecov" step succeeds
- [ ] A coverage report appears on codecov.io for this PR