### PR TITLE
feat(message): add storage lookup endpoints

### DIFF
--- a/packages/client/src/httpClient.ts
+++ b/packages/client/src/httpClient.ts
@@ -5,6 +5,7 @@ import {
   BaseMessageClient,
   CursorMessagesResponse,
   CursorPostsResponse,
+  FileMetadataResponse,
   ForgetMessageClient,
   GetAccountBalanceConfiguration,
   GetAccountBalanceResponse,
@@ -27,6 +28,7 @@ import {
   PostResponse,
   ProgramMessageClient,
   PublishedMessage,
+  StorageHashResponse,
   StoreMessageClient,
 } from '@aleph-sdk/message'
 
@@ -106,6 +108,51 @@ export class AlephHttpClient {
    */
   async downloadFile(file_hash: string): Promise<ArrayBuffer> {
     return await this.storeClient.download(file_hash)
+  }
+
+  /**
+   * Fetches a stored file by its hash, returning the base64 encoded content and its storage metadata.
+   *
+   * @param fileHash The hash of the file to retrieve.
+   */
+  async getFile(fileHash: string): Promise<StorageHashResponse> {
+    return await this.storeClient.getFile(fileHash)
+  }
+
+  /**
+   * Fetches a file's metadata from the hash of the STORE message that references it.
+   *
+   * @param messageHash The hash of the STORE message.
+   */
+  async getFileMetadataByMessageHash(messageHash: string): Promise<FileMetadataResponse> {
+    return await this.storeClient.getFileMetadataByMessageHash(messageHash)
+  }
+
+  /**
+   * Fetches a file's metadata from its reference.
+   *
+   * @param ref The reference of the file.
+   */
+  async getFileMetadataByRef(ref: string): Promise<FileMetadataResponse> {
+    return await this.storeClient.getFileMetadataByRef(ref)
+  }
+
+  /**
+   * Fetches the raw stored metadata of a file by its hash.
+   *
+   * @param fileHash The hash of the file.
+   */
+  async getFileMetadata(fileHash: string): Promise<Record<string, any>> {
+    return await this.storeClient.getFileMetadata(fileHash)
+  }
+
+  /**
+   * Fetches the number of pins referencing a given file hash.
+   *
+   * @param hash The hash of the file.
+   */
+  async getFilePinsCount(hash: string): Promise<number> {
+    return await this.storeClient.getFilePinsCount(hash)
   }
 
   /**

--- a/packages/message/__tests__/store/lookup.test.ts
+++ b/packages/message/__tests__/store/lookup.test.ts
@@ -1,0 +1,70 @@
+import axios from 'axios'
+
+import { StoreMessageClient } from '../../src'
+
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+describe('Store lookup endpoints', () => {
+  const apiServer = 'https://api.example.org'
+  const client = new StoreMessageClient(apiServer)
+  const fileHash = 'QmQkv43jguT5HLC8TPbYJi2iEmr4MgLgu4nmBoR4zjYb3L'
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('getFile queries the storage hash endpoint', async () => {
+    const data = { status: 'success', hash: fileHash, engine: 'storage', content: 'dGVzdA==' }
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data })
+
+    const res = await client.getFile(fileHash)
+
+    expect(res).toEqual(data)
+    expect(mockedAxios.get).toHaveBeenCalledWith(`${apiServer}/api/v0/storage/${fileHash}`, expect.anything())
+  })
+
+  it('getFileMetadataByMessageHash queries the by-message-hash endpoint', async () => {
+    const messageHash = 'a'.repeat(64)
+    const data = { ref: 'r', owner: '0x1', file_hash: fileHash, download_url: '/u', size: 4 }
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data })
+
+    const res = await client.getFileMetadataByMessageHash(messageHash)
+
+    expect(res).toEqual(data)
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${apiServer}/api/v0/storage/by-message-hash/${messageHash}`,
+      expect.anything(),
+    )
+  })
+
+  it('getFileMetadataByRef queries the by-ref endpoint', async () => {
+    const ref = 'my-ref'
+    const data = { ref, owner: '0x1', file_hash: fileHash, download_url: '/u', size: 4 }
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data })
+
+    const res = await client.getFileMetadataByRef(ref)
+
+    expect(res).toEqual(data)
+    expect(mockedAxios.get).toHaveBeenCalledWith(`${apiServer}/api/v0/storage/by-ref/${ref}`, expect.anything())
+  })
+
+  it('getFileMetadata queries the metadata endpoint', async () => {
+    const data = { created: 1, type: 'file' }
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data })
+
+    const res = await client.getFileMetadata(fileHash)
+
+    expect(res).toEqual(data)
+    expect(mockedAxios.get).toHaveBeenCalledWith(`${apiServer}/api/v0/storage/metadata/${fileHash}`, expect.anything())
+  })
+
+  it('getFilePinsCount queries the count endpoint and returns a number', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data: 3 })
+
+    const res = await client.getFilePinsCount(fileHash)
+
+    expect(res).toBe(3)
+    expect(mockedAxios.get).toHaveBeenCalledWith(`${apiServer}/api/v0/storage/count/${fileHash}`, expect.anything())
+  })
+})

--- a/packages/message/src/store/impl.ts
+++ b/packages/message/src/store/impl.ts
@@ -5,6 +5,8 @@ import axios, { type AxiosResponse } from 'axios'
 import {
   CostEstimationStoreContent,
   CostEstimationStorePublishConfiguration,
+  FileMetadataResponse,
+  StorageHashResponse,
   StoreContent,
   StorePinConfiguration,
   StorePublishConfiguration,
@@ -38,6 +40,67 @@ export class StoreMessageClient extends DefaultMessageClient<
       socketPath: getSocketPath(),
     })) as AxiosResponse<ArrayBuffer>
 
+    return response.data
+  }
+
+  /**
+   * Retrieves a stored file by its hash, returning the (base64 encoded) content alongside its storage metadata.
+   *
+   * @param fileHash The hash of the file to retrieve.
+   */
+  async getFile(fileHash: string): Promise<StorageHashResponse> {
+    const response = await axios.get<StorageHashResponse>(`${this.apiServer}/api/v0/storage/${fileHash}`, {
+      socketPath: getSocketPath(),
+    })
+    return response.data
+  }
+
+  /**
+   * Retrieves a file's metadata from the hash of the STORE message that references it.
+   *
+   * @param messageHash The hash of the STORE message.
+   */
+  async getFileMetadataByMessageHash(messageHash: string): Promise<FileMetadataResponse> {
+    const response = await axios.get<FileMetadataResponse>(
+      `${this.apiServer}/api/v0/storage/by-message-hash/${messageHash}`,
+      { socketPath: getSocketPath() },
+    )
+    return response.data
+  }
+
+  /**
+   * Retrieves a file's metadata from its reference.
+   *
+   * @param ref The reference of the file.
+   */
+  async getFileMetadataByRef(ref: string): Promise<FileMetadataResponse> {
+    const response = await axios.get<FileMetadataResponse>(`${this.apiServer}/api/v0/storage/by-ref/${ref}`, {
+      socketPath: getSocketPath(),
+    })
+    return response.data
+  }
+
+  /**
+   * Retrieves the raw stored metadata of a file by its hash.
+   *
+   * @param fileHash The hash of the file.
+   */
+  async getFileMetadata(fileHash: string): Promise<Record<string, any>> {
+    const response = await axios.get<Record<string, any>>(`${this.apiServer}/api/v0/storage/metadata/${fileHash}`, {
+      socketPath: getSocketPath(),
+    })
+    return response.data
+  }
+
+  /**
+   * Retrieves the number of pins referencing a given file hash.
+   *
+   * @param hash The hash of the file.
+   */
+  async getFilePinsCount(hash: string): Promise<number> {
+    const response = await axios.get<number>(`${this.apiServer}/api/v0/storage/count/${hash}`, {
+      socketPath: getSocketPath(),
+    })
     return response.data
   }
 

--- a/packages/message/src/store/types.ts
+++ b/packages/message/src/store/types.ts
@@ -81,3 +81,22 @@ export type CostEstimationStorePublishConfiguration = StorePublishConfiguration 
   estimated_size_mib?: number // int
   payment?: Payment
 }
+
+// -------- LOOKUP -----------
+
+/** Response of GET /api/v0/storage/{file_hash} — the stored file content, base64 encoded. */
+export type StorageHashResponse = {
+  status: string
+  hash: string
+  engine: string
+  content: string
+}
+
+/** Response of the by-ref and by-message-hash file metadata lookups. */
+export type FileMetadataResponse = {
+  ref: string
+  owner: string
+  file_hash: string
+  download_url: string
+  size: number
+}


### PR DESCRIPTION
Adds `StoreMessageClient` methods for the storage read endpoints and exposes them through `AlephHttpClient`:

- `getFile` — GET /api/v0/storage/{file_hash}
- `getFileMetadataByMessageHash` — GET /api/v0/storage/by-message-hash/{message_hash}
- `getFileMetadataByRef` — GET /api/v0/storage/by-ref/{ref}
- `getFileMetadata` — GET /api/v0/storage/metadata/{file_hash}
- `getFilePinsCount` — GET /api/v0/storage/count/{hash}

Includes unit tests covering URL construction and response passthrough.

Stacked on #210. `ipfs/add_car` is intentionally left out (it is a publish op requiring CARv1 root-CID derivation, not a lookup).