### PR TITLE
feat(message): add address-scoped query endpoints

### DIFF
--- a/packages/client/src/httpClient.ts
+++ b/packages/client/src/httpClient.ts
@@ -1,4 +1,7 @@
 import {
+  AddressClient,
+  AddressStatsResponse,
+  AddressStatsV1Response,
   AggregateMessageClient,
   AlephSocket,
   BalanceClient,
@@ -9,7 +12,13 @@ import {
   ForgetMessageClient,
   GetAccountBalanceConfiguration,
   GetAccountBalanceResponse,
+  GetAccountChannelsResponse,
   GetAccountCreditHistoryResponse,
+  GetAccountFilesConfiguration,
+  GetAccountFilesResponse,
+  GetAccountPostTypesResponse,
+  GetAddressStatsConfiguration,
+  GetAddressStatsV1Configuration,
   GetBalancesConfiguration,
   GetCreditBalancesConfiguration,
   GetCreditHistoryConfiguration,
@@ -41,6 +50,7 @@ export class AlephHttpClient {
   storeClient: StoreMessageClient
   messageClient: BaseMessageClient
   balanceClient: BalanceClient
+  addressClient: AddressClient
 
   constructor(apiServer?: string) {
     this.postClient = new PostMessageClient(apiServer)
@@ -51,6 +61,7 @@ export class AlephHttpClient {
     this.storeClient = new StoreMessageClient(apiServer)
     this.messageClient = new BaseMessageClient(apiServer)
     this.balanceClient = new BalanceClient(apiServer)
+    this.addressClient = new AddressClient(apiServer)
   }
 
   /**
@@ -278,6 +289,52 @@ export class AlephHttpClient {
    */
   async getConsumedCredits(itemHash: string): Promise<GetResourceConsumedCreditsResponse> {
     return await this.balanceClient.getConsumedCredits(itemHash)
+  }
+
+  /**
+   * Fetches the files stored by an address, along with their total size.
+   *
+   * @param address The address to query.
+   * @param config Optional file-hash filter, sort order and pagination.
+   */
+  async getAddressFiles(address: string, config: GetAccountFilesConfiguration = {}): Promise<GetAccountFilesResponse> {
+    return await this.addressClient.getFiles(address, config)
+  }
+
+  /**
+   * Fetches the POST types used by an address.
+   *
+   * @param address The address to query.
+   */
+  async getAddressPostTypes(address: string): Promise<GetAccountPostTypesResponse> {
+    return await this.addressClient.getPostTypes(address)
+  }
+
+  /**
+   * Fetches the channels used by an address.
+   *
+   * @param address The address to query.
+   */
+  async getAddressChannels(address: string): Promise<GetAccountChannelsResponse> {
+    return await this.addressClient.getChannels(address)
+  }
+
+  /**
+   * Fetches message statistics for one or more addresses (v0 endpoint).
+   *
+   * @param config Optional list of addresses to filter on.
+   */
+  async getAddressStats(config: GetAddressStatsConfiguration = {}): Promise<AddressStatsResponse> {
+    return await this.addressClient.getStats(config)
+  }
+
+  /**
+   * Fetches paginated message statistics across addresses (v1 endpoint).
+   *
+   * @param config Optional substring filter, sort and pagination.
+   */
+  async getAddressStatsV1(config: GetAddressStatsV1Configuration = {}): Promise<AddressStatsV1Response> {
+    return await this.addressClient.getStatsV1(config)
   }
 }
 

--- a/packages/message/__tests__/address/get.test.ts
+++ b/packages/message/__tests__/address/get.test.ts
@@ -1,0 +1,95 @@
+import axios from 'axios'
+
+import { AddressClient } from '../../src'
+
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+describe('Address-scoped queries', () => {
+  const apiServer = 'https://api.example.org'
+  const client = new AddressClient(apiServer)
+  const address = '0x1234567890123456789012345678901234567890'
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('getFiles maps camelCase config to snake_case query params', async () => {
+    const data = {
+      address,
+      total_size: 4,
+      files: [{ file_hash: 'Qm', size: 4, type: 'file', created: '2024', item_hash: 'h' }],
+      pagination_page: 1,
+      pagination_total: 1,
+      pagination_per_page: 100,
+    }
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data })
+
+    const res = await client.getFiles(address, { sortOrder: -1, fileHash: 'Qm', page: 2 })
+
+    expect(res).toEqual(data)
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${apiServer}/api/v0/addresses/${address}/files`,
+      expect.objectContaining({
+        params: expect.objectContaining({ sort_order: -1, file_hash: 'Qm', page: 2 }),
+      }),
+    )
+  })
+
+  it('getPostTypes queries the post_types endpoint', async () => {
+    const data = { address, post_types: ['my-type'] }
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data })
+
+    const res = await client.getPostTypes(address)
+
+    expect(res).toEqual(data)
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${apiServer}/api/v0/addresses/${address}/post_types`,
+      expect.anything(),
+    )
+  })
+
+  it('getChannels queries the channels endpoint', async () => {
+    const data = { address, channels: ['TEST'] }
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data })
+
+    const res = await client.getChannels(address)
+
+    expect(res).toEqual(data)
+    expect(mockedAxios.get).toHaveBeenCalledWith(`${apiServer}/api/v0/addresses/${address}/channels`, expect.anything())
+  })
+
+  it('getStats (v0) normalizes a single address into an array param', async () => {
+    const data = { data: { messages: 5 } }
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data })
+
+    const res = await client.getStats({ addresses: address })
+
+    expect(res).toEqual(data)
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${apiServer}/api/v0/addresses/stats.json`,
+      expect.objectContaining({ params: { addresses: [address] } }),
+    )
+  })
+
+  it('getStatsV1 forwards the v1 filter and pagination params', async () => {
+    const data = {
+      data: {},
+      pagination_per_page: 100,
+      pagination_page: 1,
+      pagination_total: 0,
+      pagination_item: 'stats',
+    }
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data })
+
+    const res = await client.getStatsV1({ addressContains: 'abc', sortBy: 'messages', sortOrder: -1 })
+
+    expect(res).toEqual(data)
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${apiServer}/api/v1/addresses/stats.json`,
+      expect.objectContaining({
+        params: expect.objectContaining({ addressContains: 'abc', sortBy: 'messages', sortOrder: -1 }),
+      }),
+    )
+  })
+})

--- a/packages/message/src/address/impl.ts
+++ b/packages/message/src/address/impl.ts
@@ -1,0 +1,111 @@
+import { DEFAULT_API_V2, getSocketPath, stripTrailingSlash } from '@aleph-sdk/core'
+import axios from 'axios'
+
+import {
+  AddressStatsResponse,
+  AddressStatsV1Response,
+  GetAccountChannelsResponse,
+  GetAccountFilesConfiguration,
+  GetAccountFilesResponse,
+  GetAccountPostTypesResponse,
+  GetAddressStatsConfiguration,
+  GetAddressStatsV1Configuration,
+} from './types'
+
+export class AddressClient {
+  apiServer: string
+
+  constructor(apiServer: string = DEFAULT_API_V2) {
+    this.apiServer = stripTrailingSlash(apiServer)
+  }
+
+  /**
+   * Retrieves the files stored by an address, along with their total size.
+   *
+   * @param address The address to query.
+   * @param config Optional file-hash filter, sort order and pagination.
+   */
+  async getFiles(
+    address: string,
+    { pagination, page, sortOrder, fileHash }: GetAccountFilesConfiguration = {},
+  ): Promise<GetAccountFilesResponse> {
+    const response = await axios.get<GetAccountFilesResponse>(`${this.apiServer}/api/v0/addresses/${address}/files`, {
+      params: {
+        pagination,
+        page,
+        sort_order: sortOrder,
+        file_hash: fileHash,
+      },
+      socketPath: getSocketPath(),
+    })
+    return response.data
+  }
+
+  /**
+   * Retrieves the POST types used by an address.
+   *
+   * @param address The address to query.
+   */
+  async getPostTypes(address: string): Promise<GetAccountPostTypesResponse> {
+    const response = await axios.get<GetAccountPostTypesResponse>(
+      `${this.apiServer}/api/v0/addresses/${address}/post_types`,
+      { socketPath: getSocketPath() },
+    )
+    return response.data
+  }
+
+  /**
+   * Retrieves the channels used by an address.
+   *
+   * @param address The address to query.
+   */
+  async getChannels(address: string): Promise<GetAccountChannelsResponse> {
+    const response = await axios.get<GetAccountChannelsResponse>(
+      `${this.apiServer}/api/v0/addresses/${address}/channels`,
+      { socketPath: getSocketPath() },
+    )
+    return response.data
+  }
+
+  /**
+   * Retrieves message statistics for one or more addresses (v0 endpoint).
+   *
+   * @param config Optional list of addresses to filter on.
+   */
+  async getStats({ addresses }: GetAddressStatsConfiguration = {}): Promise<AddressStatsResponse> {
+    const response = await axios.get<AddressStatsResponse>(`${this.apiServer}/api/v0/addresses/stats.json`, {
+      params: {
+        addresses: addresses === undefined ? undefined : Array.isArray(addresses) ? addresses : [addresses],
+      },
+      socketPath: getSocketPath(),
+    })
+    return response.data
+  }
+
+  /**
+   * Retrieves paginated message statistics across addresses (v1 endpoint).
+   *
+   * @param config Optional substring filter, sort and pagination.
+   */
+  async getStatsV1({
+    addressContains,
+    sortBy,
+    sortOrder,
+    pagination,
+    page,
+  }: GetAddressStatsV1Configuration = {}): Promise<AddressStatsV1Response> {
+    const response = await axios.get<AddressStatsV1Response>(`${this.apiServer}/api/v1/addresses/stats.json`, {
+      params: {
+        addressContains,
+        sortBy,
+        sortOrder,
+        pagination,
+        page,
+      },
+      socketPath: getSocketPath(),
+    })
+    return response.data
+  }
+}
+
+export default AddressClient

--- a/packages/message/src/address/index.ts
+++ b/packages/message/src/address/index.ts
@@ -1,0 +1,2 @@
+export { default, AddressClient } from './impl'
+export * from './types'

--- a/packages/message/src/address/types.ts
+++ b/packages/message/src/address/types.ts
@@ -1,0 +1,69 @@
+// ------- GET /api/v0/addresses/{address}/files -------
+
+export type AccountFile = {
+  file_hash: string
+  size: number
+  type: string
+  created: string
+  item_hash: string
+}
+
+export type GetAccountFilesConfiguration = {
+  pagination?: number
+  page?: number
+  sortOrder?: number
+  /** If set, only return the file with this hash (if owned by the address). */
+  fileHash?: string
+}
+
+export type GetAccountFilesResponse = {
+  address: string
+  total_size: number
+  files: AccountFile[]
+  pagination_page: number
+  pagination_total: number
+  pagination_per_page: number
+}
+
+// ------- GET /api/v0/addresses/{address}/post_types -------
+
+export type GetAccountPostTypesResponse = {
+  address: string
+  post_types: string[]
+}
+
+// ------- GET /api/v0/addresses/{address}/channels -------
+
+export type GetAccountChannelsResponse = {
+  address: string
+  channels: string[]
+}
+
+// ------- GET /api/v0/addresses/stats.json -------
+
+export type GetAddressStatsConfiguration = {
+  addresses?: string | string[]
+}
+
+export type AddressStatsResponse = {
+  data: Record<string, any>
+}
+
+// ------- GET /api/v1/addresses/stats.json -------
+
+export type GetAddressStatsV1Configuration = {
+  /** Case-insensitive substring filter for addresses. */
+  addressContains?: string
+  sortBy?: string
+  sortOrder?: number
+  pagination?: number
+  page?: number
+}
+
+export type AddressStatsV1Response = {
+  data: Record<string, any>
+  pagination_per_page: number
+  pagination_page: number
+  pagination_total: number
+  pagination_item: string
+}

--- a/packages/message/src/index.ts
+++ b/packages/message/src/index.ts
@@ -1,3 +1,4 @@
+export * from './address'
 export * from './aggregate'
 export * from './balance'
 export * from './base'


### PR DESCRIPTION
Adds an `AddressClient` for the address-scoped read endpoints and exposes them through `AlephHttpClient`:

- `getFiles` — GET /api/v0/addresses/{address}/files
- `getPostTypes` — GET /api/v0/addresses/{address}/post_types
- `getChannels` — GET /api/v0/addresses/{address}/channels
- `getStats` — GET /api/v0/addresses/stats.json (v0)
- `getStatsV1` — GET /api/v1/addresses/stats.json

Includes unit tests covering query-param mapping and response passthrough.

Stacked on #212.