### PR TITLE
feat(message): add message status endpoint

### DIFF
--- a/packages/client/src/httpClient.ts
+++ b/packages/client/src/httpClient.ts
@@ -30,6 +30,7 @@ import {
   InstanceMessageClient,
   MessageContent,
   MessageError,
+  MessageStatusInfo,
   MessageType,
   PaginatedBalances,
   PaginatedCreditBalances,
@@ -197,6 +198,16 @@ export class AlephHttpClient {
    */
   async getMessageError(itemHash: string): Promise<MessageError | null> {
     return await this.messageClient.getError(itemHash)
+  }
+
+  /**
+   * Fetches the processing status of a message (pending, processed, rejected or forgotten),
+   * along with its reception time, without fetching the message content.
+   *
+   * @param itemHash The hash of the message to query.
+   */
+  async getMessageStatus(itemHash: string): Promise<MessageStatusInfo> {
+    return await this.messageClient.getStatus(itemHash)
   }
 
   /**

--- a/packages/message/__tests__/base/status.test.ts
+++ b/packages/message/__tests__/base/status.test.ts
@@ -1,0 +1,35 @@
+import axios from 'axios'
+
+import { BaseMessageClient, MessageNotFoundError, MessageStatus } from '../../src'
+
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+describe('Message status retrieval', () => {
+  const apiServer = 'https://api.example.org'
+  const client = new BaseMessageClient(apiServer)
+  const itemHash = 'f'.repeat(64)
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('getStatus returns the status info from the status endpoint', async () => {
+    const data = { status: MessageStatus.processed, item_hash: itemHash, reception_time: '2024-01-01T00:00:00Z' }
+    mockedAxios.isAxiosError.mockReturnValue(false)
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data })
+
+    const res = await client.getStatus(itemHash)
+
+    expect(res).toEqual(data)
+    expect(mockedAxios.get).toHaveBeenCalledWith(`${apiServer}/api/v0/messages/${itemHash}/status`, expect.anything())
+  })
+
+  it('getStatus throws MessageNotFoundError on a 404', async () => {
+    const error = { isAxiosError: true, response: { status: 404 } }
+    mockedAxios.isAxiosError.mockReturnValue(true)
+    mockedAxios.get.mockRejectedValueOnce(error)
+
+    await expect(client.getStatus(itemHash)).rejects.toThrow(MessageNotFoundError)
+  })
+})

--- a/packages/message/src/base/impl.ts
+++ b/packages/message/src/base/impl.ts
@@ -13,7 +13,14 @@ import {
   MessageResponse,
   MessagesQueryResponse,
 } from './types'
-import { MessageContent, MessageStatus, MessageType, MessageTypeMap, PublishedMessage } from '../types'
+import {
+  MessageContent,
+  MessageStatus,
+  MessageStatusInfo,
+  MessageType,
+  MessageTypeMap,
+  PublishedMessage,
+} from '../types'
 import { AlephSocket, getMessagesSocket, GetMessagesSocketConfiguration } from './websocket'
 import { ForgottenMessageError, MessageNotFoundError, QueryError } from '../types/errors'
 import { toQueryParam } from '../utils'
@@ -101,6 +108,28 @@ export class BaseMessageClient {
     return {
       error_code: data.error_code,
       details: data.details,
+    }
+  }
+
+  /**
+   * Retrieves the processing status of a message (pending, processed, rejected or forgotten).
+   *
+   * Lighter than {@link get}: it returns only the status and reception time, without the
+   * message content.
+   *
+   * @param item_hash The hash of the message to query.
+   */
+  async getStatus(item_hash: string): Promise<MessageStatusInfo> {
+    try {
+      const response = await axios.get<MessageStatusInfo>(`${this.apiServer}/api/v0/messages/${item_hash}/status`, {
+        socketPath: getSocketPath(),
+      })
+      return response.data
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        throw new MessageNotFoundError(`No such hash ${item_hash}`)
+      }
+      throw error
     }
   }
 

--- a/packages/message/src/base/impl.ts
+++ b/packages/message/src/base/impl.ts
@@ -117,6 +117,11 @@ export class BaseMessageClient {
    * Lighter than {@link get}: it returns only the status and reception time, without the
    * message content.
    *
+   * Unlike {@link get} and {@link getError}, a forgotten message is returned as data with
+   * status "forgotten" rather than throwing ForgottenMessageError. Callers must inspect the
+   * returned status field; no exception is thrown for forgotten, rejected or pending states.
+   * Only a missing hash (404) throws (MessageNotFoundError).
+   *
    * @param item_hash The hash of the message to query.
    */
   async getStatus(item_hash: string): Promise<MessageStatusInfo> {

--- a/packages/message/src/types/messages.ts
+++ b/packages/message/src/types/messages.ts
@@ -177,6 +177,12 @@ export enum MessageStatus {
   forgotten = 'forgotten',
 }
 
+export type MessageStatusInfo = {
+  status: MessageStatus
+  item_hash: ItemHash
+  reception_time: string
+}
+
 export type ProgramMessage = SignedMessage<ProgramContent>
 export type InstanceMessage = SignedMessage<InstanceContent>
 export type StoreMessage = SignedMessage<StoreContent>


### PR DESCRIPTION
Adds first-class access to a message's processing status, which the SDK previously did not expose.

`BaseMessageClient.getStatus(itemHash)` calls `GET /api/v0/messages/{hash}/status` and returns `MessageStatusInfo { status, item_hash, reception_time }` — the status (`pending`/`processed`/`rejected`/`forgotten`) and reception time, without fetching the full message content. Exposed through `AlephHttpClient.getMessageStatus`.

Until now the status was only reachable indirectly: `get()` reads it internally but returns only the message, and `getError()` returns `null` for both pending and processed, so callers had no way to read a message's status. This is the lighter, purpose-built path for polling (e.g. waiting for a just-published message to become `processed`).

404 maps to `MessageNotFoundError`, consistent with `get()`. Includes unit tests.