### PR TITLE
fix(deps): bump sha.js to 2.4.12 (critical)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29577,16 +29577,23 @@
       "license": "ISC"
     },
     "node_modules/sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
       "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
       },
       "bin": {
         "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/sha3": {
@@ -33933,6 +33940,26 @@
         "@types/filesystem": "*",
         "@types/har-format": "*"
       }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
     }
   }
 }

--- a/packages/avalanche/package.json
+++ b/packages/avalanche/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "eciesjs": "^0.4.6",
-    "sha.js": "^2.4.11"
+    "sha.js": "^2.4.12"
   },
   "peerDependencies": {
     "@aleph-sdk/account": "^1.x.x",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "eciesjs": "^0.4.6",
-    "sha.js": "^2.4.11"
+    "sha.js": "^2.4.12"
   },
   "peerDependencies": {
     "@aleph-sdk/account": "^1.x.x",

--- a/packages/message/package.json
+++ b/packages/message/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "axios": "^1.5.1",
     "form-data": "^4.0.0",
-    "sha.js": "^2.4.11"
+    "sha.js": "^2.4.12"
   },
   "peerDependencies": {
     "@aleph-sdk/account": "^1.x.x",

--- a/packages/nuls2/package.json
+++ b/packages/nuls2/package.json
@@ -24,7 +24,7 @@
     "eciesjs": "^0.3.14",
     "ripemd160": "^2.0.2",
     "secp256k1": "^5.0.0",
-    "sha.js": "^2.4.11"
+    "sha.js": "^2.4.12"
   },
   "peerDependencies": {
     "@aleph-sdk/account": "^1.x.x",


### PR DESCRIPTION
sha.js <=2.4.11 is missing type checks that allow a hash rewind on crafted input (GHSA, critical). 2.4.12 is the patch fix.

The bump stays within the existing `^2.4.11` caret range, so it is non-breaking. Updated the declared constraint to `^2.4.12` in the four packages that depend on it (base, avalanche, nuls2, message) and refreshed the lockfile.

The lockfile change is surgical: only the sha.js entry plus its one new transitive dependency (to-buffer, and a nested isarray@2.0.5 matching the existing nesting pattern). Validated with `npm ci --dry-run`. Account and hashing tests pass unchanged (22/22 across avalanche, base, nuls2, and the message store).