### PR TITLE
fix(deps): raise elliptic floor to 6.6.1 in cosmos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33724,7 +33724,7 @@
       "version": "1.7.4",
       "license": "MIT",
       "dependencies": {
-        "elliptic": "^6.5.4"
+        "elliptic": "^6.6.1"
       },
       "peerDependencies": {
         "@aleph-sdk/account": "^1.x.x",

--- a/packages/cosmos/package.json
+++ b/packages/cosmos/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "dependencies": {
-    "elliptic": "^6.5.4"
+    "elliptic": "^6.6.1"
   },
   "peerDependencies": {
     "@aleph-sdk/account": "^1.x.x",


### PR DESCRIPTION
elliptic has 7 advisories. Six are fixed in 6.6.0/6.6.1, which is what cosmos's `^6.5.4` already resolves to. This raises the declared floor to `^6.6.1` so a 6.5.x (which reintroduces those six) can never be resolved.

The seventh advisory (GHSA-848j-6mx2-7j84, 'risky cryptographic primitive', affects `<=6.6.1`) has no fixed release yet, so it cannot be addressed by a version bump; it stays until upstream ships a fix.

Lockfile change is a single line (the cosmos dependency constraint); the resolved elliptic stays 6.6.1. Cosmos signing tests pass unchanged. Older transitive elliptic copies under `avalanche` and `@truffle` (dev) are separate.