### PR TITLE
fix(message): wrap STORE file in Blob so uploaded bytes match item_hash

### DIFF
--- a/packages/message/__tests__/store/upload.test.ts
+++ b/packages/message/__tests__/store/upload.test.ts
@@ -1,0 +1,53 @@
+import axios from 'axios'
+import shajs from 'sha.js'
+
+import * as ethereum from '../../../ethereum/src'
+import { StoreMessageClient } from '../../src'
+
+jest.mock('axios')
+
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+function sha256Hex(data: Buffer): string {
+  return new shajs.sha256().update(data).digest('hex')
+}
+
+describe('Store message upload byte integrity', () => {
+  const store = new StoreMessageClient()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  // Regression: a binary Buffer used to be coerced to a UTF-8 string by FormData,
+  // so the uploaded bytes no longer matched item_hash and the API returned
+  // "422 File hash does not match".
+  it('uploads the exact bytes that were hashed for a binary Buffer', async () => {
+    const { account } = ethereum.newAccount()
+    // High bytes (> 0x7F) are the ones UTF-8 coercion corrupts. JPEG magic + tail.
+    const fileContent = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0xc3, 0xa9, 0x80, 0xff, 0xd9])
+
+    let uploadedForm: FormData | undefined
+    mockedAxios.post.mockImplementation(async (url: string, data: unknown) => {
+      if (url.endsWith('/api/v0/storage/add_file')) {
+        uploadedForm = data as FormData
+        return { data: { status: 'success', hash: 'irrelevant' } }
+      }
+      throw new Error(`unexpected POST to ${url}`)
+    })
+
+    const message = await store.send({
+      channel: 'TEST',
+      account,
+      fileObject: fileContent,
+    })
+
+    expect(uploadedForm).toBeDefined()
+    const filePart = uploadedForm!.get('file')
+    expect(filePart).toBeInstanceOf(Blob)
+
+    const sentBytes = Buffer.from(await (filePart as Blob).arrayBuffer())
+    expect(sha256Hex(sentBytes)).toBe(message.content.item_hash)
+    expect(message.content.item_hash).toBe(sha256Hex(fileContent))
+  })
+})

--- a/packages/message/src/store/impl.ts
+++ b/packages/message/src/store/impl.ts
@@ -141,7 +141,7 @@ export class StoreMessageClient extends DefaultMessageClient<
     } else if (!fileObject) {
       throw new Error('You need to specify a File to upload or a Hash to pin.')
     } else {
-      const { message } = await this.uploadStore(hashedMessage, account, fileObject as Blob | File, sync || false)
+      const { message } = await this.uploadStore(hashedMessage, account, fileObject, sync || false)
       return message
     }
   }
@@ -174,7 +174,7 @@ export class StoreMessageClient extends DefaultMessageClient<
   protected async uploadStore(
     message: HashedMessage<StoreContent>,
     account: Account,
-    file: Blob | File,
+    file: Blob | Buffer | Uint8Array,
     sync: boolean,
   ): Promise<{ message: SignedMessage<StoreContent>; response: { status: string; hash: string } }> {
     const form = new FormData()
@@ -186,8 +186,13 @@ export class StoreMessageClient extends DefaultMessageClient<
       message: signedMessage.getBroadcastable(),
       sync,
     }
+    // @note: A Buffer/Uint8Array is coerced to a UTF-8 string by FormData, which
+    // corrupts binary content and makes the uploaded bytes differ from item_hash
+    // (server returns "File hash does not match"). Wrap it in a Blob so the bytes
+    // sent are exactly the bytes that were hashed.
+    const filePart = file instanceof Blob ? file : new Blob([file])
     form.append('metadata', JSON.stringify(metadata))
-    form.append('file', file)
+    form.append('file', filePart)
     try {
       const response = await axios.post(`${this.apiServer}/api/v0/storage/add_file`, form, {
         headers: {


### PR DESCRIPTION
## Problem

Uploading a file to STORE with a Node \`Buffer\` (a documented supported type: \`fileObject?: Buffer | Blob\`) fails with:

\`\`\`
422 File hash does not match (<computed> != <declared>)
\`\`\`

## Cause

\`StoreMessageClient\` hashes and sends two different representations of the same file:

- Hash path (\`prepareMessageContent\` -> \`calculateSHA256Hash\`): hashes the raw \`Buffer\` bytes, and that hash becomes \`content.item_hash\`.
- Send path (\`uploadStore\`): \`form.append('file', fileObject)\` appends the raw \`Buffer\` to Node's global \`FormData\` (undici), which coerces a \`Buffer\`/\`Uint8Array\` to a UTF-8 string. Every non-ASCII byte is mangled, so the uploaded bytes differ from the hashed bytes and the file grows.

The server hashes the received (corrupted) bytes and rejects the upload because it does not match \`item_hash\`. Binary files (images, archives) always hit this; browser \`File\`/\`Blob\` uploads are unaffected.

## Fix

Wrap non-\`Blob\` file parts in a \`Blob\` before appending, so the bytes sent equal the bytes hashed. Verified for plain buffers and pooled/offset views.

## Test

Adds an offline regression test that captures the FormData posted to \`add_file\` and asserts the uploaded bytes hash to \`content.item_hash\`, using binary bytes (> 0x7F). Confirmed it fails before the fix and passes after.